### PR TITLE
Fix bug with finding dags

### DIFF
--- a/whirl
+++ b/whirl
@@ -63,7 +63,7 @@ function export_environment_vars() {
 }
 
 detect_potential_dag() {
-  test -f $(pwd)/*.py || test -f $(pwd)/*.zip;
+  test `find . -type f -name '*.py' -o -name '*.zip' | wc -l` -gt 0
 }
 
 test_dag_state() {


### PR DESCRIPTION
If the working directory contains more than one py file, the old bash
command would throw an error. This commit resolves that