### PR TITLE
Export WHIRL_INITIATOR env var

### DIFF
--- a/whirl
+++ b/whirl
@@ -13,6 +13,7 @@ function export_environment_vars() {
   DOCKER_CONTEXT_FOLDER=${SCRIPT_DIR}/docker
   DAG_FOLDER=$(pwd)
   PROJECTNAME=$(basename ${DAG_FOLDER})
+  WHIRL_INITIATOR=$(whoami)
   WHIRL_SETUP_FOLDER=/etc/airflow/whirl.setup.d
 
   if [ -f ~/.whirl.env ]; then


### PR DESCRIPTION
I have a use case where I need to know who initiated the _whirl_ script, by exporting it I can make it available in the docker-compose environment variables