### PR TITLE
Remove update-ca-certificates which results in command not found

### DIFF
--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -24,8 +24,7 @@ ENV AIRFLOW_HOME /usr/local/airflow
 ENV AIRFLOW_GPL_UNIDECODE=yes
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 
-RUN update-ca-certificates -f \
-  && apt-get update \
+RUN  apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --reinstall build-essential \
   && apt-get install -y --allow-unauthenticated \


### PR DESCRIPTION
@DPGrev tried to build the Dockerfile but ran into the issue that `update-ca-certificates` wasn't found. Also, after removing the line the container built completely. 