### PR TITLE
Fix failing airflow-python image build (broken by pymssql)

### DIFF
--- a/docker/airflow-python/Dockerfile
+++ b/docker/airflow-python/Dockerfile
@@ -51,7 +51,8 @@ ENV PIP_NO_CACHE_DIR=${PIP_NO_CACHE_DIR}
 
 RUN pip install --upgrade pip \
     && pip install apache-airflow[all_dbs,atlas,async,cassandra,celery,cgroups,cloudant,crypto,dask,databricks,datadog,doc,docker,druid,elasticsearch,gcp_api,github_enterprise,google_auth,hdfs,hive,jdbc,jira,kerberos,ldap,mongo,mssql,mysql,oracle,password,pinot,postgres,qds,rabbitmq,redis,salesforce,samba,sendgrid,segment,slack,snowflake,ssh,statsd,vertica,webhdfs,winrm]=="${AIRFLOW_VERSION}" \
-    && mkdir -p "${AIRFLOW_HOME}/dags" \
+    'pymssql<3.0' \
+    && mkdir -p "${AIRFLOW_HOME}/dags"
 
 RUN mkdir -p "${WHIRL_SETUP_FOLDER}/env.d"
 RUN mkdir -p "${WHIRL_SETUP_FOLDER}/dag.d"


### PR DESCRIPTION
Currently the build of the airflow-python image fails due to issues with the pymssql package, which is apparently no longer being mantained. This PR fixes the version of pymssql to an older version (<3.0) as recommended in the error message, so that the build no longer fails.