### PR TITLE
Fix reference to docker-compose file which did not use $ENVIRONMENT_FOLDER

### DIFF
--- a/whirl
+++ b/whirl
@@ -192,12 +192,12 @@ start() {
 
 stop() {
   echo "Stopping airflow-localrun containers..."
-  docker-compose -f "${SCRIPT_DIR}/envs/${WHIRL_ENVIRONMENT}/docker-compose.yml" down --volumes --rmi local --remove-orphans
+  docker-compose -f "${ENVIRONMENT_FOLDER}/docker-compose.yml" down --volumes --rmi local --remove-orphans
 }
 
 logs() {
   echo "Showing logs of airflow-localrun service ${WHIRL_SERVICE_NAME}"
-  docker-compose -f "${SCRIPT_DIR}/envs/${WHIRL_ENVIRONMENT}/docker-compose.yml" logs -f "${WHIRL_SERVICE_NAME}"
+  docker-compose -f "${ENVIRONMENT_FOLDER}/docker-compose.yml" logs -f "${WHIRL_SERVICE_NAME}"
 }
 
 usage() {


### PR DESCRIPTION
Hello whirl maintainers!

I've just started using whirl and I love it so far. It has made the task of setting up a local Airflow development environment so much simpler.

I'm submitting this PR because I noticed what I think is a bug in a few docker-compose commands. These commands assumed that the `whirl` script lives in the same folder as `envs`. If we use the `ENVIRONMENT_FOLDER` environment variable instead, these functions will run successfully on any configured `envs` directory.

Please let me know if I'm mistaken here, but in my testing this seems like a real bug.