### PR TITLE
Set right path for Java when on Apple Silicon

### DIFF
--- a/envs/dbt-example/whirl.setup.d/03_add_spark_config.sh
+++ b/envs/dbt-example/whirl.setup.d/03_add_spark_config.sh
@@ -4,7 +4,13 @@ echo "======== Add java =========="
 echo "============================"
 
 sudo apt-get update && sudo apt-get install -y openjdk-11-jre
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Use the right path on Apple Silicon
+if [ $(uname -m) == "aarch64" ]; then
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
+else
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+fi
 
 echo "============================"
 echo "== Configure Spark config =="

--- a/envs/postgres-s3-external-spark/whirl.setup.d/03_add_spark_config.sh
+++ b/envs/postgres-s3-external-spark/whirl.setup.d/03_add_spark_config.sh
@@ -4,7 +4,13 @@ echo "======== Add java =========="
 echo "============================"
 
 sudo apt-get update && sudo apt-get install -y openjdk-11-jre
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Use the right path on Apple Silicon
+if [ $(uname -m) == "aarch64" ]; then
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
+else
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+fi
 
 echo "============================"
 echo "== Configure Spark config =="

--- a/envs/postgres-s3-spark/whirl.setup.d/03_add_spark_config.sh
+++ b/envs/postgres-s3-spark/whirl.setup.d/03_add_spark_config.sh
@@ -4,7 +4,13 @@ echo "======== Add java =========="
 echo "============================"
 
 sudo apt-get update && sudo apt-get install -y openjdk-11-jre
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Use the right path on Apple Silicon
+if [ $(uname -m) == "aarch64" ]; then
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
+else
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+fi
 
 echo "============================"
 echo "== Configure Spark config =="

--- a/envs/s3-external-spark-hive/whirl.setup.d/03_add_spark_config.sh
+++ b/envs/s3-external-spark-hive/whirl.setup.d/03_add_spark_config.sh
@@ -4,7 +4,13 @@ echo "======== Add java =========="
 echo "============================"
 
 sudo apt-get update && sudo apt-get install -y openjdk-11-jre
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Use the right path on Apple Silicon
+if [ $(uname -m) == "aarch64" ]; then
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
+else
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+fi
 
 echo "============================"
 echo "== Configure Spark config =="

--- a/envs/s3-spark-delta-sharing-minio/whirl.setup.d/02_add_spark_config.sh
+++ b/envs/s3-spark-delta-sharing-minio/whirl.setup.d/02_add_spark_config.sh
@@ -4,7 +4,13 @@ echo "======== Add java =========="
 echo "============================"
 
 sudo apt-get update && sudo apt-get install -y openjdk-11-jre
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Use the right path on Apple Silicon
+if [ $(uname -m) == "aarch64" ]; then
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
+else
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+fi
 
 echo "============================"
 echo "== Configure Spark config =="

--- a/envs/s3-spark-delta-sharing-riverbank/whirl.setup.d/02_add_spark_config.sh
+++ b/envs/s3-spark-delta-sharing-riverbank/whirl.setup.d/02_add_spark_config.sh
@@ -4,7 +4,13 @@ echo "======== Add java =========="
 echo "============================"
 
 sudo apt-get update && sudo apt-get install -y openjdk-11-jre
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Use the right path on Apple Silicon
+if [ $(uname -m) == "aarch64" ]; then
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
+else
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+fi
 
 echo "============================"
 echo "== Configure Spark config =="

--- a/envs/s3-spark-delta-sharing/whirl.setup.d/02_add_spark_config.sh
+++ b/envs/s3-spark-delta-sharing/whirl.setup.d/02_add_spark_config.sh
@@ -4,7 +4,13 @@ echo "======== Add java =========="
 echo "============================"
 
 sudo apt-get update && sudo apt-get install -y openjdk-11-jre
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Use the right path on Apple Silicon
+if [ $(uname -m) == "aarch64" ]; then
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
+else
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+fi
 
 echo "============================"
 echo "== Configure Spark config =="


### PR DESCRIPTION
The path was hardcoded and included 'amd64', which did not work on arm64 (Apple Silicon) architectures.