### PR TITLE
Fill documentation gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to Whirl
+
+Thanks for your interest in contributing to _whirl_! This document describes how
+to propose changes and what we expect from a contribution.
+
+## Ways to contribute
+
+- **Report a bug** — open a [GitHub issue](https://github.com/godatadriven/whirl/issues)
+  describing what you did, what you expected and what actually happened. Include
+  your OS, Docker version, the example/environment used and relevant log output.
+- **Suggest an improvement** — open an issue to discuss larger changes before
+  you start, so we can agree on the approach.
+- **Add an example or environment** — see [Adding examples and environments](#adding-examples-and-environments).
+- **Improve documentation** — README, example READMEs and inline comments are
+  all fair game.
+
+## Development workflow
+
+1. Fork the repository and create a feature branch off `master`
+   (e.g. `git checkout -b my-improvement`).
+2. Make your change in small, focused commits with descriptive messages.
+3. Make sure your change passes the checks described in [Testing](#testing).
+4. Open a pull request against `master` describing **what** changed and **why**.
+   Link any related issue.
+
+### Pull request expectations
+
+- Keep PRs focused: one logical change per PR is much easier to review.
+- Update documentation (README / example README) when behaviour changes.
+- If you change the main `whirl` script, an environment or an example, list the
+  examples you ran to verify the change in the PR description.
+- CI must be green before a PR can be merged.
+
+## Shell script style guide
+
+The main `whirl` script and the setup scripts under `whirl.setup.d/` and
+`compose.setup.d/` are Bash. Please follow these conventions:
+
+- Start scripts with `#!/usr/bin/env bash`.
+- Add `set -e` (and where appropriate `set -euo pipefail`) so failures stop the
+  script instead of silently continuing.
+- **Quote your variables**: `"${VAR}"`, not `$VAR`, especially for paths.
+- Prefer functions for repeated logic over copy-pasting (e.g. reuse the
+  `airflow_api` helper in `whirl` instead of hand-writing `curl` calls).
+- All shell code must pass [`shellcheck`](https://www.shellcheck.net/). CI runs
+  `shellcheck -x whirl`; run it locally before pushing:
+
+  ```bash
+  shellcheck -x whirl
+  shellcheck examples/**/whirl.setup.d/*.sh
+  ```
+
+- When you intentionally ignore a `shellcheck` finding, add a
+  `# shellcheck disable=SCXXXX` comment explaining why.
+
+## Testing
+
+There is no unit-test suite yet; verification is done by running examples
+end-to-end in CI mode, which builds the Docker image, starts the environment,
+triggers the DAG and asserts it succeeds.
+
+```bash
+# Run a single example headless (requires Docker and jq)
+whirl -x api-to-s3 ci
+
+# Or from inside an example directory
+cd examples/api-to-s3 && ../../whirl ci
+```
+
+Run the examples affected by your change before opening a PR. If you use the
+Claude Code skills bundled in this repo, the `verify-ci-impact` skill maps your
+changed files to the examples that need a CI run.
+
+## Adding examples and environments
+
+- New examples live under `examples/<name>/` and should include a `dag.py`, a
+  `.whirl.env` and a `README.md` describing what the example demonstrates and
+  how to run it.
+- New environments live under `envs/<name>/` and contain a `docker-compose.yml`,
+  a `.whirl.env` and any `whirl.setup.d/` scripts.
+- The repo ships Claude Code skills (`create-example`, `create-environment`)
+  that scaffold these for you — see [CLAUDE.md](CLAUDE.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[Apache License 2.0](LICENSE), the same license that covers this project.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ When you want to use _whirl_ in your CI pipeline, you need to have `jq` installe
 brew install jq
 ```
 
-The current implementation was developed on macOS but is intended to work with any platform supported by Docker. In our experience, Linux and macOS are fine. You can run it on native Windows 10 using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about). Unfortunately, Docker on Windows 10 (version 1809) is hamstrung because it relies on Windows File Sharing (CIFS) to establish the volume mounts. Airflow hammers the volume a little harder than CIFS can handle, and you'll see intermittent FileNotFound errors in the volume mount. This may improve in the future. For now, running _whirl_ inside a Linux VM in Hyper-V gives more reliable results.
+The current implementation was developed on macOS but is intended to work with any platform supported by Docker. In our experience, Linux and macOS are fine. On Windows we recommend running _whirl_ inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/about) on Windows 11 (or Windows 10) with the [Docker Desktop WSL2 backend](https://docs.docker.com/desktop/wsl/). Keeping your DAG code on the Linux filesystem inside WSL2 (rather than on a `/mnt/c` Windows mount) avoids the file-sharing/volume-mount issues that older native-Windows setups suffered from.
 
 ### Airflow Versions
-As of January 2021, Whirl uses Airflow 2.x.x as the default version. A specific tag was made for Airflow 1.10.x, which can be found [here](https://github.com/godatadriven/whirl/tree/airflow-1.10.x)
+Whirl currently uses Airflow 3.2.1 as the default version (configurable through the `AIRFLOW_VERSION` environment variable). A specific tag was made for Airflow 1.10.x, which can be found [here](https://github.com/godatadriven/whirl/tree/airflow-1.10.x)
 
 ## Getting Started
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Scope: Whirl is a local development tool
+
+_whirl_ exists to spin up Apache Airflow and supporting services (S3, databases,
+Spark, etc.) **on your local machine** for development and testing of DAGs. It
+is **not** intended to be deployed as a production service or exposed to a
+network.
+
+### Intentional "insecure" defaults
+
+To keep local usage frictionless, _whirl_ ships with hardcoded, well-known
+credentials and secrets. **These are intentional and safe only because
+everything runs locally and is not exposed to the internet.** They include,
+among others:
+
+- The Airflow admin user `admin` / `admin`.
+- Default AWS-style access keys/secrets used to talk to the local S3 mock.
+- Sample passphrases used when generating throwaway certificates in the Docker
+  image build.
+
+Do **not** reuse any of these credentials, keys or certificates outside of a
+local _whirl_ environment, and do not expose a running _whirl_ stack (for
+example the Airflow UI on `localhost:5000`) to untrusted networks.
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue in the _whirl_ tooling itself
+(for example in the `whirl` script, the Docker image build, or a setup script)
+that goes beyond the intentional local-development defaults described above,
+please report it privately rather than opening a public issue:
+
+- Preferred: use GitHub's
+  [private vulnerability reporting](https://github.com/godatadriven/whirl/security/advisories/new)
+  to open a security advisory for this repository.
+- Alternatively, contact the maintainers through the
+  [godatadriven/whirl](https://github.com/godatadriven/whirl) repository.
+
+Please include:
+
+- A description of the issue and its potential impact;
+- Steps to reproduce (the example/environment used, commands run);
+- Any relevant logs or proof-of-concept.
+
+We will acknowledge your report, investigate, and work with you on a fix and
+coordinated disclosure where appropriate.

--- a/examples/airflow-cluster-policy/README.md
+++ b/examples/airflow-cluster-policy/README.md
@@ -1,0 +1,37 @@
+#### Airflow Cluster Policy Example
+
+In this example we demonstrate how to enforce an [Airflow cluster
+policy](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/cluster-policies.html).
+Cluster policies let an operator apply organisation-wide rules to every DAG or
+task that is loaded, for example to enforce tagging, naming or resource
+conventions.
+
+The policy in this example (`whirl.setup.d/policies/dag_policy.py`) implements a
+`dag_policy` that requires every DAG to have at least one tag. When a DAG does
+not comply it raises an `AirflowClusterPolicyViolation`, which surfaces as a DAG
+import error.
+
+The bundled DAG (`example_bash_operator`) deliberately has **no tags**, so
+loading it violates the policy. This example therefore *expects* an import
+error: the `.whirl.env` sets `WHIRL_CI_EXPECT_IMPORTERRORS=true` so that the
+import error is treated as the successful outcome in CI mode.
+
+The default environment (`just-airflow`) only contains the core Airflow
+component.
+
+The environment contains a setup script in the `whirl.setup.d/` folder:
+
+ - `01_configure_cluster_policies.sh` which installs `policies/dag_policy.py`
+   as `${AIRFLOW_HOME}/config/airflow_local_settings.py`, the file Airflow reads
+   cluster policies from.
+
+To run this example:
+
+```bash
+$ cd ./examples/airflow-cluster-policy
+$ whirl
+```
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access
+the Airflow UI. The DAG will show up as a broken DAG / import error, proving the
+cluster policy is being enforced.

--- a/examples/airflow-deferrable-operator-custom/README.md
+++ b/examples/airflow-deferrable-operator-custom/README.md
@@ -1,0 +1,49 @@
+#### Custom Deferrable Operator Example
+
+In this example we demonstrate how to build your **own** [deferrable
+sensor](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html)
+together with a custom `Trigger`, rather than using a built-in one (for the
+built-in variant see the
+[airflow-deferrable-operator](../airflow-deferrable-operator) example).
+
+The custom code lives under `src/custom/` and is packaged with the included
+`setup.py`:
+
+ - `operators/api_check_operator.py` — `WaitForStartedStatusSensor`, a sensor
+   whose `execute` immediately `self.defer(...)`s onto a custom trigger and
+   resumes in `execute_complete` once the trigger fires.
+ - `triggers/api_check_trigger.py` — `ApiCheckTrigger`, an async trigger that
+   polls a REST API every second (using `aiohttp`) until the API returns a
+   given status, then emits a single `TriggerEvent`.
+
+The DAG (`example_custom_sensor_async`) waits for the API to report status
+`Started` and then runs a downstream `EmptyOperator`.
+
+This example uses the `airflow-with-mockserver` environment, which adds a
+[MockServer](https://www.mock-server.com/) instance next to the core Airflow
+component.
+
+The environment contains a setup script in the `whirl.setup.d/` folder:
+
+ - `01_add_connection_api_and_mockdata.sh` which:
+
+   - Registers two MockServer expectations for `/testapi`: it returns
+     `{"status": "Pending"}` for the first 30 calls and `{"status": "Started"}`
+     afterwards, so the trigger has to poll for a while before completing;
+   - Installs the custom Python package (and `aiohttp`) so the operator and
+     trigger are importable by both the worker and the triggerer.
+
+> **Note:** deferrable operators require Airflow 2.3.0 or higher. This is
+> enforced through `MINIMAL_AIRFLOW_VERSION=2.3.0` in the example `.whirl.env`.
+
+To run this example:
+
+```bash
+$ cd ./examples/airflow-deferrable-operator-custom
+$ whirl
+```
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access
+the Airflow UI. Trigger the DAG and watch the `wait` task enter the `deferred`
+state while the trigger polls MockServer, then complete once the status flips to
+`Started`.

--- a/examples/airflow-deferrable-operator/README.md
+++ b/examples/airflow-deferrable-operator/README.md
@@ -1,0 +1,34 @@
+#### Deferrable Operator Example
+
+In this example we demonstrate Airflow [deferrable
+operators](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html).
+A deferrable operator (or sensor) can suspend itself and hand its waiting work
+over to the Airflow *triggerer*, freeing up the worker slot while it waits.
+This makes long waits (for a time window, a file, an external job, ...) much
+cheaper in terms of resources.
+
+The DAG (`example_time_delta_sensor_async`) uses the built-in
+`TimeDeltaSensorAsync`, a drop-in replacement for `TimeDeltaSensor` that defers
+instead of blocking a worker. It waits 120 seconds and then runs a downstream
+`EmptyOperator`.
+
+The default environment (`just-airflow`) only contains the core Airflow
+component (which includes the triggerer needed to run deferrable tasks).
+
+> **Note:** deferrable operators require Airflow 2.3.0 or higher. This is
+> enforced through `MINIMAL_AIRFLOW_VERSION=2.3.0` in the example `.whirl.env`.
+
+To run this example:
+
+```bash
+$ cd ./examples/airflow-deferrable-operator
+$ whirl
+```
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access
+the Airflow UI. Manually trigger the DAG and watch the `wait` task enter the
+`deferred` state before completing.
+
+For a custom implementation of a deferrable sensor (with its own Trigger), see
+the [airflow-deferrable-operator-custom](../airflow-deferrable-operator-custom)
+example.

--- a/examples/airflow-timetable/README.md
+++ b/examples/airflow-timetable/README.md
@@ -1,0 +1,35 @@
+#### Custom Timetable Example
+
+In this example we demonstrate a custom [Airflow
+timetable](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timetable.html).
+Timetables let you express scheduling logic that cannot be captured by a cron
+expression or a fixed interval.
+
+The timetable in this example (`FullMoonTimetable`) schedules a DAG run on every
+full moon. It uses the [`ephem`](https://pypi.org/project/ephem/) astronomy
+library to compute the previous/next full moon dates and is shipped as an
+[Airflow plugin](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/plugins.html)
+(`FullMoonTimetablePlugin`).
+
+The DAG (`example_timetable`) uses `schedule=FullMoonTimetable()` and runs a
+single `BashOperator` that echoes the data interval of each run.
+
+The default environment (`just-airflow`) only contains the core Airflow
+component.
+
+The custom plugin lives under `whirl.setup.d/plugins/` and the environment
+contains a setup script in the `whirl.setup.d/` folder:
+
+ - `01_install_custom_timetable.sh` which `pip install`s the plugin package
+   (including its `ephem` dependency) so the timetable is registered with
+   Airflow.
+
+To run this example:
+
+```bash
+$ cd ./examples/airflow-timetable
+$ whirl
+```
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access
+the Airflow UI. The DAG's next run will be scheduled for the upcoming full moon.

--- a/examples/dbt-example/README.md
+++ b/examples/dbt-example/README.md
@@ -1,0 +1,48 @@
+#### DBT Example (S3 → Postgres → dbt)
+
+In this example we are going to:
+
+1. Download a zip with flights data from S3 and unzip it;
+2. Upload the extracted `airports`, `carriers` and `flights` CSV files back to
+   S3;
+3. Use Spark (`SparkSubmitOperator`) to load each CSV into a PostgreSQL
+   database;
+4. Run [dbt](https://www.getdbt.com/) models on top of those tables to build
+   enriched, transformed models;
+5. Run the dbt tests to validate the result.
+
+dbt is orchestrated from Airflow with the
+[`airflow-dbt-python`](https://github.com/tomasfarias/airflow-dbt-python)
+`DbtRunOperator` / `DbtTestOperator`. The dbt project lives in the `dbt/` folder
+and targets the `airflow` profile (PostgreSQL).
+
+This example uses the `dbt-example` environment, which includes containers for:
+
+ - A S3 server;
+ - A PostgreSQL database;
+ - A Spark cluster;
+ - The core Airflow component.
+
+The environment contains setup scripts in the `whirl.setup.d/` folder:
+
+ - `01_add_mockdata_to_s3.sh` which uploads the mock flights data
+   (`mock-data/flights_data.zip`) to the S3 bucket;
+ - `02_install_postgres_dbt.sh` which installs the dbt PostgreSQL adapter and
+   the `airflow-dbt-python` operators.
+
+There are also `compose.setup.d/` and `compose.teardown.d/` scripts that clean
+and then display the dbt log around the run for easier debugging.
+
+To run this example:
+
+```bash
+$ cd ./examples/dbt-example
+$ whirl
+```
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access
+the Airflow UI. Manually enable the `whirl-dbt-example` DAG and watch the
+pipeline run to successful completion.
+
+For a variant that loads into Hive (instead of PostgreSQL) and uses the dbt Spark
+adapter, see the [dbt-spark-example](../dbt-spark-example).

--- a/examples/dbt-spark-example/README.md
+++ b/examples/dbt-spark-example/README.md
@@ -1,0 +1,50 @@
+#### DBT + Spark Example (S3 → Hive → dbt)
+
+In this example we are going to:
+
+1. Download a zip with flights data from S3 and unzip it;
+2. Upload the extracted `airports`, `carriers` and `flights` CSV files back to
+   S3;
+3. Use Spark (`SparkSubmitOperator`) to load each CSV into a Hive-backed data
+   warehouse on S3;
+4. Run [dbt](https://www.getdbt.com/) models on top of those Hive tables to
+   build enriched, transformed models;
+5. Run the dbt tests to validate the result.
+
+This is the Hive/Spark counterpart of the [dbt-example](../dbt-example): instead
+of loading into PostgreSQL it stores the data as Hive tables (via the Hive
+metastore) and the dbt project targets the `hive` profile (the dbt Spark
+adapter).
+
+This example uses the `s3-external-spark-hive` environment, which includes
+containers for:
+
+ - A S3 server;
+ - A Hive metastore;
+ - A Spark cluster;
+ - The core Airflow component.
+
+The dbt project lives in the `dbt/` folder and is orchestrated from Airflow with
+the [`airflow-dbt-python`](https://github.com/tomasfarias/airflow-dbt-python)
+operators.
+
+The environment contains setup scripts in the `whirl.setup.d/` folder:
+
+ - `01_add_mockdata_to_s3.sh` which uploads the mock flights data
+   (`mock-data/flights_data.zip`) to the S3 bucket;
+ - `02_add_dbt.sh` which installs dbt with the Spark adapter and the
+   `airflow-dbt-python` operators.
+
+There are also `compose.setup.d/` and `compose.teardown.d/` scripts that clean
+and then display the dbt log around the run for easier debugging.
+
+To run this example:
+
+```bash
+$ cd ./examples/dbt-spark-example
+$ whirl
+```
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access
+the Airflow UI. Manually enable the `whirl-dbt-spark-example` DAG and watch the
+pipeline run to successful completion.

--- a/examples/spark-s3-to-hive/README.md
+++ b/examples/spark-s3-to-hive/README.md
@@ -1,0 +1,38 @@
+#### Spark S3 to Hive Example
+
+In this example we use Spark to read data from S3 and store it in a Hive table:
+
+1. Mock JSON input data is uploaded to S3;
+2. A Spark job (`SparkSubmitOperator`) reads the data from S3 and writes it to a
+   Hive-backed table on S3 (via the Hive metastore).
+
+The Spark application (`spark/s3tohive.py`) is configured through the
+`spark_conf` in the DAG to talk to both the S3 server and the Hive metastore
+(`thrift://hive:9083`).
+
+This example uses the `s3-external-spark-hive` environment, which includes
+containers for:
+
+ - A S3 server;
+ - A Hive metastore;
+ - A Spark cluster;
+ - The core Airflow component.
+
+The environment contains a setup script in the `whirl.setup.d/` folder:
+
+ - `01_add_mockdata_to_s3.sh` which uploads the mock input data
+   (`mock-data/input.json`) to the S3 bucket.
+
+To run this example:
+
+```bash
+$ cd ./examples/spark-s3-to-hive
+$ whirl
+```
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access
+the Airflow UI. Manually enable the `spark-s3-to-hive` DAG and watch the
+pipeline run to successful completion.
+
+For a variant that writes to PostgreSQL (and adds a row-count check) instead of
+Hive, see the [spark-s3-to-postgres](../spark-s3-to-postgres) example.

--- a/examples/spark-s3-to-postgres/README.md
+++ b/examples/spark-s3-to-postgres/README.md
@@ -1,0 +1,47 @@
+#### Spark S3 to PostgreSQL Example
+
+In this example we use Spark to read data from S3 and store it in a PostgreSQL
+table, then verify the result:
+
+1. Mock JSON input data is uploaded to S3;
+2. A Spark job (`SparkSubmitOperator`) reads the data from S3 and writes it to a
+   PostgreSQL table;
+3. A `SQLCheckOperator` runs a `SELECT COUNT(*)` against the table to confirm
+   the data was loaded.
+
+The Spark application (`spark/s3topostgres.py`) is configured through the
+`spark_conf` in the DAG to talk to the S3 server, and the check uses the
+`local_pg` Airflow connection.
+
+This example uses the `postgres-s3-external-spark` environment, which includes
+containers for:
+
+ - A S3 server;
+ - A PostgreSQL database;
+ - A Spark cluster;
+ - The core Airflow component.
+
+The environment contains setup scripts in the `whirl.setup.d/` folder:
+
+ - `01_add_mockdata_to_s3.sh` which uploads the mock input data
+   (`mock-data/input.json`) to the S3 bucket;
+ - `03_install_airflow_providers.sh` which installs the additional Airflow
+   providers required by this example.
+
+> **Note:** the `SQLCheckOperator` used here requires Airflow 2.3.0 or higher.
+> This is enforced through `MINIMAL_AIRFLOW_VERSION=2.3.0` in the example
+> `.whirl.env`.
+
+To run this example:
+
+```bash
+$ cd ./examples/spark-s3-to-postgres
+$ whirl
+```
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access
+the Airflow UI. Manually enable the `spark-s3-to-postgres` DAG and watch the
+pipeline run to successful completion.
+
+For a variant that writes to a Hive table instead of PostgreSQL, see the
+[spark-s3-to-hive](../spark-s3-to-hive) example.


### PR DESCRIPTION
Implements **Topic 2 (Documentation Gaps)** from `CLAUDE_IMPROVEMENTS.md`.

## Changes (documentation only)
- **2.1** Added `CONTRIBUTING.md` (PR workflow, shell style guide, testing expectations).
- **2.2** Added `SECURITY.md`, clarifying that hardcoded credentials (admin/admin, AWS keys, build passphrase) are **intentional for local development**, plus a private vulnerability-reporting process.
- **2.3** Added READMEs for 8 previously undocumented examples: `airflow-cluster-policy`, `airflow-deferrable-operator`, `airflow-deferrable-operator-custom`, `airflow-timetable`, `dbt-example`, `dbt-spark-example`, `spark-s3-to-hive`, `spark-s3-to-postgres`.
- **2.4** Updated outdated `README.md` content: Windows 11 / WSL2 guidance and the default Airflow version (now **3.2.1**).

> The doc listed `dbt-athena-glue-example` too, but that example is untracked on `master` (work-in-progress) so it isn't included here.

## Validation
- ci-verifier confirmed the branch's commit is **Markdown-only** (11 `.md` files, 0 functional files) → no CI run required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)