### PR TITLE
Add Claude Code skills, ci-verifier agent, and project guidance

### DIFF
--- a/.claude/agents/ci-verifier.md
+++ b/.claude/agents/ci-verifier.md
@@ -1,0 +1,126 @@
+---
+name: ci-verifier
+description: >-
+  Verifies that the current branch's changes still pass by running the affected
+  Whirl examples in CI mode, outside the caller's session/context. Delegate to
+  this agent when you want changes validated without blocking the main
+  conversation — e.g. "verify my changes in the background", "run CI for what I
+  changed", "check nothing is broken before I commit/open a PR", or as the
+  verification stage of an agent team. It figures out which example/environment
+  combinations are impacted via the verify-ci-impact skill, runs them, and
+  returns a pass/fail report. Being dispatched IS the authorization to run the
+  CI checks — it does not pause to ask permission.
+tools: Bash, Read, Glob, Grep, Skill, TodoWrite
+model: sonnet
+---
+
+# CI Verification Agent
+
+You verify that changes on the current branch still work by running the impacted
+Whirl examples in CI mode. You run in your own context — typically in the
+background or as one member of an agent team — so the caller can keep working.
+Your job is to come back with a clear, trustworthy verdict on what passed, what
+failed, and what you didn't run.
+
+You have been dispatched specifically to do this verification. That dispatch is
+your authorization: **do not wait for further confirmation before running CI.**
+The interactive `verify-ci-impact` skill normally asks a human for permission
+before running — that gate exists for an in-session human, and it has already
+been satisfied by the act of launching you. You still produce the plan first
+(below), but then you execute it.
+
+## Inputs you may receive
+
+The prompt may include any of these; apply sensible defaults if absent:
+
+- **base ref** — branch to diff against (default: `master`).
+- **scope** — which combinations to run: `all`, a specific subset (named
+  examples), or `plan-only` (identify but don't run). Default: run everything the
+  plan identifies, with the CORE caveat below.
+- **fail-fast** — stop at the first failure, or run all and report. Default: run
+  all so the report is complete.
+
+## Workflow
+
+### 1. Build the plan
+
+Determine the impacted `(example, environment)` combinations using the
+verify-ci-impact skill's script (the source of truth for the mapping — it knows
+default envs and the non-default extra-env CI jobs):
+
+```bash
+.claude/skills/verify-ci-impact/scripts/ci_impact.sh --base <base>
+```
+
+Read its output. It lists the changed areas, any CORE change, the combinations to
+verify (each tagged default or NON-default), and the exact commands. If you want
+the full reasoning behind the mapping, consult the `verify-ci-impact` skill.
+
+Record the planned commands in your TODO list so your progress is visible and you
+don't lose track across long-running runs.
+
+### 2. Decide scope (especially for CORE changes)
+
+- **No combinations + no CORE change** — nothing to verify. Report that only
+  non-functional files changed and stop. This is a valid, successful outcome.
+- **CORE change** (`whirl`, `docker/`, `docker-compose.yaml`, root `.whirl.env`)
+  — this affects every example, which can be ~19 Docker runs. Unless the prompt
+  said `all`, run the representative subset the script suggests (covers S3/API,
+  Spark, dbt, DB+SFTP, just-airflow) rather than everything. State clearly in
+  your report that you ran a subset and that a full run may be warranted.
+- **Honor an explicit scope** from the prompt over these defaults.
+
+If scope is `plan-only`, report the plan and stop without running anything.
+
+### 3. Run the checks
+
+Run each approved combination from the repo root, using the exact command from
+the plan:
+
+```bash
+./whirl -x <example> ci            # default-env combination
+./whirl -x <example> ci -e <env>   # non-default-env combination
+```
+
+Critical execution notes:
+
+- **Run sequentially, one at a time.** Each run spins up a full Docker stack;
+  parallel runs contend for ports and memory and produce flaky failures.
+- **Use a long Bash timeout** (e.g. 600000 ms). CI mode builds images, starts
+  containers, triggers the default DAG, waits for completion, then tears down —
+  this takes minutes per example.
+- **Capture the outcome of each run.** CI mode exits non-zero on DAG failure;
+  treat exit code as the source of truth. On failure, capture the tail of the
+  output (the error and failing task) for the report.
+- **Ensure cleanup between runs.** `whirl ci` tears down on its own, but if a run
+  errors out, run `./whirl stop` before the next one so leftover containers don't
+  poison it.
+- If `fail-fast` is set, stop at the first failure; otherwise continue so the
+  report covers every combination.
+
+### 4. Report back
+
+Return a concise, structured verdict — this is the whole point of running outside
+the caller's context, so make it self-contained and skimmable:
+
+```
+## CI verification: <PASS | FAIL | NOTHING TO VERIFY>
+
+Base: <ref>   Combinations planned: N   Ran: M   Skipped: K
+
+| Example | Env | Result | Notes |
+|---------|-----|--------|-------|
+| api-to-s3 | api-python-s3 (default) | ✅ pass | |
+| api-to-s3 | api-python-s3-k8s (non-default) | ❌ fail | task `extract` errored: <1-line reason> |
+
+### Failures
+<for each failure: the example/env, the failing task, and the key error lines>
+
+### Not run / caveats
+<e.g. "CORE change — ran 5-example representative subset, full run recommended",
+or excluded-from-CI examples that need more memory>
+```
+
+Overall status is FAIL if any run failed, PASS if all ran and passed, and
+NOTHING TO VERIFY if the plan was empty. Be honest: if you skipped something or a
+run was inconclusive, say so plainly rather than implying full coverage.

--- a/.claude/plugins/whirl/.claude-plugin/plugin.json
+++ b/.claude/plugins/whirl/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "whirl",
+  "version": "1.0.0",
+  "description": "Skills for the Whirl local Airflow development tool: scaffold new examples, create Docker Compose environments, and bump Airflow/Python versions.",
+  "author": { "name": "GoDataDriven" },
+  "license": "MIT",
+  "keywords": ["whirl", "airflow", "docker", "examples", "environments"]
+}

--- a/.claude/plugins/whirl/skills/create-environment
+++ b/.claude/plugins/whirl/skills/create-environment
@@ -1,0 +1,1 @@
+../../../skills/create-environment

--- a/.claude/plugins/whirl/skills/create-example
+++ b/.claude/plugins/whirl/skills/create-example
@@ -1,0 +1,1 @@
+../../../skills/create-example

--- a/.claude/plugins/whirl/skills/verify-ci-impact
+++ b/.claude/plugins/whirl/skills/verify-ci-impact
@@ -1,0 +1,1 @@
+../../../skills/verify-ci-impact

--- a/.claude/plugins/whirl/skills/version-bumper
+++ b/.claude/plugins/whirl/skills/version-bumper
@@ -1,0 +1,1 @@
+../../../skills/version-bumper

--- a/.claude/skills/create-environment/SKILL.md
+++ b/.claude/skills/create-environment/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: create-environment
+description: Create a new Whirl environment in the envs/ directory. Use when the user wants to add, scaffold, or create a new Docker Compose environment for the Whirl local Airflow development tool. Also invoked by the create-example skill when the user needs a custom environment. Triggers on requests like "create a new environment", "add an environment for Kafka", "I need an environment with Redis and S3".
+---
+
+# Create Whirl Environment
+
+Scaffold a new Whirl environment in `envs/`. Gather requirements interactively, then generate all files.
+
+## Workflow
+
+### 1. Gather Requirements
+
+Ask the user for:
+
+1. **Environment name** - short kebab-case name describing the services (e.g. `postgres-s3-spark`, `sftp-mysql-example`)
+2. **Services needed** - which external services to include. Common options:
+   - **S3** - LocalStack (`localstack/localstack:3.0.2`, port 4566)
+   - **PostgreSQL** - (`postgres:16`, port 5432)
+   - **MySQL** - (`mysql:8`, port 3306)
+   - **MockServer** - REST API mocking (`mockserver/mockserver:5.15.0`, port 1080)
+   - **Spark** - Master + Worker cluster
+   - **SFTP** - (`atmoz/sftp`, port 22)
+   - **SMTP** - MailDev (`maildev/maildev:2.0.5`, ports 1080/1025)
+   - **Redis**, **Kafka**, or other custom services
+3. **Airflow mode** - how Airflow should run:
+   - `singlemachine` (default) - scheduler + webserver in one container, simplest setup
+   - Distributed - separate `api-server`, `scheduler`, `dag-processor`, `triggerer` containers (for testing HA or distributed setups)
+
+### 2. Create Files
+
+Create `envs/<name>/` with these files:
+
+#### `docker-compose.yml` (required)
+
+Follow these patterns:
+
+**Airflow service (singlemachine mode):**
+```yaml
+services:
+  airflow:
+    image: docker-whirl-airflow:py-${PYTHON_VERSION}-local
+    command: ["singlemachine"]
+    ports:
+      - '5000:5000'
+    env_file:
+      - .whirl.env
+    environment:
+      - WHIRL_SETUP_FOLDER
+      - AIRFLOW__FAB__AUTH_BACKENDS
+      - AIRFLOW__CORE__EXECUTION_API_SERVER_URL
+      - AIRFLOW__API_AUTH__JWT_SECRET
+    volumes:
+      - ${DAG_FOLDER}:/opt/airflow/dags/$PROJECTNAME
+      - ${ENVIRONMENT_FOLDER}/whirl.setup.d:${WHIRL_SETUP_FOLDER}/env.d/
+      - ${DAG_FOLDER}/whirl.setup.d:${WHIRL_SETUP_FOLDER}/dag.d/
+```
+
+**Adding service dependencies:**
+```yaml
+    depends_on:
+      - s3server
+      - postgresdb
+    links:
+      - s3server:${DEMO_BUCKET}.s3server  # Only for S3 virtual-host style access
+```
+
+**Common service definitions:**
+
+S3 (LocalStack):
+```yaml
+  s3server:
+    image: localstack/localstack:3.0.2
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=s3
+    env_file:
+      - .whirl.env
+```
+
+PostgreSQL:
+```yaml
+  postgresdb:
+    image: postgres:16
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_HOST=postgresdb
+      - POSTGRES_PORT=5432
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB}
+```
+
+MockServer:
+```yaml
+  mockserver:
+    image: mockserver/mockserver:5.15.0
+    ports:
+      - 1080:1080
+    environment:
+      - LOG_LEVEL=ERROR
+      - SERVER_PORT=1080
+```
+
+MySQL:
+```yaml
+  mysql:
+    image: mysql:8
+    ports:
+      - 3306:3306
+    env_file:
+      - mysql.env
+```
+
+SMTP (MailDev):
+```yaml
+  smtp-server:
+    image: maildev/maildev:2.0.5
+    ports:
+      - "1080:1080"
+      - "1025:1025"
+```
+
+**Mock data volume (when needed):**
+Add to the airflow service volumes:
+```yaml
+      - ${MOCK_DATA_FOLDER}:/mock-data
+```
+
+#### `.whirl.env` (required)
+
+Standard variables always included:
+```
+AIRFLOW_VERSION=3.2.1
+AIRFLOW__CORE__EXPOSE_CONFIG=True
+AIRFLOW__API__EXPOSE_CONFIG=True
+AIRFLOW__API__SECRET_KEY=webser_secret_key
+AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS=False
+AIRFLOW__CORE__LOAD_EXAMPLES=False
+```
+
+Add service-specific variables based on chosen services:
+
+For S3:
+```
+AWS_ACCESS_KEY_ID=bar
+AWS_SECRET_ACCESS_KEY=foo
+DEMO_BUCKET=demo-s3-output
+AWS_SERVER=s3server
+AWS_PORT=4566
+```
+
+For PostgreSQL:
+```
+POSTGRES_HOST=postgresdb
+POSTGRES_PORT=5432
+POSTGRES_PASSWORD=p@ssw0rd
+POSTGRES_USER=postgres
+POSTGRES_DB=postgresdb
+```
+
+For SMTP:
+```
+AIRFLOW__SMTP__SMTP_HOST=smtp-server
+AIRFLOW__SMTP__SMTP_PORT=2525
+AIRFLOW__SMTP__SMTP_MAIL_FROM=sender@example.com
+```
+
+For distributed Airflow (add fernet key and DB connection):
+```
+AIRFLOW__CORE__FERNET_KEY=YlCImzjge_TeZc7jPJ7Jz2pgOtb4yTssA1pVyqIADWg=
+AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+```
+
+#### `whirl.setup.d/` scripts (optional but typical)
+
+Create numbered shell scripts for environment initialization. Common scripts:
+
+**S3 connection setup** (`01_add_connection_s3.sh`):
+```bash
+#!/usr/bin/env bash
+
+echo "=========================="
+echo "== Configure S3 =========="
+echo "=========================="
+
+pip install awscli
+
+export AWS_ENDPOINT_URL="http://${AWS_SERVER}:${AWS_PORT}"
+
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' ${AWS_ENDPOINT_URL})" != "200" ]]; do
+  echo "Waiting for S3 server..."
+  sleep 2
+done
+
+aws s3 mb s3://${DEMO_BUCKET}
+
+airflow connections add aws_default \
+  --conn-type aws \
+  --conn-extra "{\"endpoint_url\": \"http://${AWS_SERVER}:${AWS_PORT}\"}"
+```
+
+**PostgreSQL connection setup** (`02_add_connection_postgres.sh`):
+```bash
+#!/usr/bin/env bash
+
+echo "=============================="
+echo "== Configure PostgreSQL ======"
+echo "=============================="
+
+airflow connections add postgres_default \
+  --conn-type postgres \
+  --conn-host ${POSTGRES_HOST} \
+  --conn-port ${POSTGRES_PORT} \
+  --conn-login ${POSTGRES_USER} \
+  --conn-password ${POSTGRES_PASSWORD} \
+  --conn-schema ${POSTGRES_DB}
+```
+
+Scripts must use `#!/usr/bin/env bash` and include wait loops for service readiness when needed.
+
+#### `compose.setup.d/` scripts (optional)
+
+Host-side scripts executed before Docker Compose starts. Use for:
+- Cleaning persistent data directories (e.g., `.pgdata/`)
+- Building custom Docker images
+- Pre-provisioning resources
+
+#### Additional env files (optional)
+
+For services needing separate env files (e.g., `mysql.env`, `sftp.env`).
+
+### 3. Verify
+
+After creating files:
+- Confirm `docker-compose.yml` is valid YAML
+- Ensure `.whirl.env` variable names match service names in `docker-compose.yml`
+- Setup scripts are executable: `chmod +x envs/<name>/whirl.setup.d/*.sh`

--- a/.claude/skills/create-example/SKILL.md
+++ b/.claude/skills/create-example/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: create-example
+description: Create a new Whirl example project in the examples/ directory. Use when the user wants to scaffold, add, or create a new Airflow DAG example for the Whirl local development tool. Triggers on requests like "create a new example", "add an example", "scaffold an example for X".
+---
+
+# Create Whirl Example
+
+Scaffold a new Whirl example in `examples/`. Gather requirements interactively, then generate all files.
+
+## Workflow
+
+### 1. Gather Requirements
+
+Ask the user for:
+
+1. **Example name** - short kebab-case name (e.g. `api-to-s3`, `sftp-mysql-example`)
+2. **Use case** - what the example demonstrates (1-2 sentences)
+3. **Environment** - which environment from `envs/` to use. Present the available options:
+   - `just-airflow` - Minimal Airflow only
+   - `api-python-s3` - Airflow + S3 (LocalStack) + MockServer
+   - `api-s3-dataset` - Airflow + S3 + PostgreSQL + MockServer
+   - `postgres-s3-spark` - Airflow + PostgreSQL + S3 + Spark cluster
+   - `dbt-example` - DBT + PostgreSQL + S3 + Spark
+   - `sftp-mysql-example` - Airflow + MySQL + SFTP server
+   - `local-ssh` - Airflow + SSH
+   - `external-airflow-db` - Airflow with external PostgreSQL
+   - `external-smtp-config` - Airflow + MailDev SMTP
+   - `airflow-s3-logging` - Airflow with S3-based logging
+   - `ha-scheduler` - High availability scheduler setup
+   - `s3-spark-delta-sharing` - Spark + Delta Sharing + S3
+   - **Custom environment** - if none of the above fit, use the `create-environment` skill to create a new environment first
+4. **Optional extras** - whether the example needs:
+   - Setup scripts (`whirl.setup.d/`) for installing providers, adding connections, loading mock data
+   - Mock data directory (`mock-data/`)
+   - Additional Python dependencies
+
+### 2. Create Files
+
+Create `examples/<name>/` with these files:
+
+#### `.whirl.env` (required)
+
+Minimum content:
+```
+WHIRL_ENVIRONMENT=<environment-name>
+```
+
+Add extra variables only when needed:
+```
+MOCK_DATA_FOLDER=${DAG_FOLDER}/mock-data
+```
+
+#### `README.md` (required)
+
+Follow this structure:
+```markdown
+#### <Descriptive Title> Example
+
+<1-2 paragraphs describing what this example demonstrates.>
+
+The default environment (`<env>`) includes containers for:
+
+ - <list services from the chosen environment>
+
+## Setup scripts
+
+The environment contains setup scripts in the `whirl.setup.d/` folder:
+
+ - `<script>` which <description>
+
+## Running
+
+\`\`\`bash
+$ cd ./examples/<name>
+$ whirl
+\`\`\`
+
+Open your browser to [http://localhost:5000](http://localhost:5000) to access the Airflow UI. Manually enable the DAG and watch the pipeline run.
+```
+
+#### `dag.py` (required)
+
+Create a DAG file demonstrating the use case. Follow these conventions:
+- Use `os.environ.get()` for connection details and configuration
+- Use Airflow templating (`{{ ds_nodash }}`, `{{ logical_date }}`) where appropriate
+- Use providers matching the chosen environment's services
+- Set `schedule=None` unless a specific schedule is needed
+- Include a descriptive `dag_id` and `description`
+
+#### `whirl.setup.d/` scripts (optional)
+
+Numbered shell scripts executed inside the container at startup. Naming convention:
+- `01_add_connection_<name>.sh` - add Airflow connections
+- `01_add_mockdata_to_<service>.sh` - load mock data
+- `02_install_<packages>.sh` - install extra Python packages
+
+Scripts use `#!/usr/bin/env bash` and run after environment setup scripts.
+
+Common patterns:
+```bash
+# Add a connection
+airflow connections add <conn_id> --conn-type <type> --conn-host <host> --conn-port <port>
+
+# Install providers
+pip install apache-airflow-providers-<name>
+
+# Create S3 bucket and upload mock data
+aws s3 mb s3://<bucket> --endpoint-url http://localstack:4566
+aws s3 cp /mock-data/<file> s3://<bucket>/ --endpoint-url http://localstack:4566
+```
+
+#### `mock-data/` (optional)
+
+Test data files (JSON, CSV, etc.) referenced by setup scripts or DAGs. Set `MOCK_DATA_FOLDER=${DAG_FOLDER}/mock-data` in `.whirl.env` when using this.
+
+#### `.airflowignore` (optional)
+
+Add when the example directory contains Python files that are not DAGs (e.g. `include/` or `src/` directories):
+```
+include/
+src/
+```
+
+### 3. Verify
+
+After creating files, verify:
+- The example directory exists in `examples/`
+- `.whirl.env` references a valid environment from `envs/`
+- The DAG file has no syntax errors: `python -c "import ast; ast.parse(open('examples/<name>/dag.py').read())"`
+- Setup scripts (if any) are executable

--- a/.claude/skills/verify-ci-impact/SKILL.md
+++ b/.claude/skills/verify-ci-impact/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: verify-ci-impact
+description: Before committing, work out which Whirl examples need a CI run to verify changes still work, then run them after confirming with the user. Use whenever the user is about to commit and asks "what should I test / verify before committing", "which examples does this change affect", "run CI for what I changed", or wants to validate edits to examples, envs, or core whirl files. Identifies the CI runs first and asks permission before running anything.
+---
+
+# Verify CI Impact
+
+When code changes in this repo, only a subset of the ~19 examples actually need
+to be re-verified. Running every example is slow (each spins up Docker and an
+Airflow run), and running the wrong ones gives false confidence. This skill maps
+the changed files to the exact set of examples to verify, presents that plan, and
+only runs CI after the user agrees.
+
+The two phases are deliberately separate: **identify first, run second.** Never
+start CI runs before the user has seen the plan and approved it — they may want to
+narrow the scope, skip the heavy ones, or commit without running anything.
+
+## How impact is determined
+
+The unit of verification is an `(example, environment)` combination, not just an
+example. Most examples run against one environment — their **default**, set in
+`examples/<name>/.whirl.env` (`WHIRL_ENVIRONMENT=<env>`). But the GitHub Actions
+workflow (`.github/workflows/whirl-ci.yml`) also runs a few examples against a
+**non-default** environment in separate "extra-env" jobs via `whirl ci -e <env>`
+(e.g. `api-to-s3` on `api-python-s3-k8s`, `external-airflow-db` on `ha-scheduler`,
+`spark-s3-to-postgres` on `postgres-s3-spark`). Those combinations must be verified
+too, so the script parses them straight from the workflow.
+
+The mapping rules (encoded in `scripts/ci_impact.sh`):
+
+| Changed path | Combinations to verify |
+|---|---|
+| `examples/<name>/...` | `<name>` against **every** env CI runs it with — its default env *and* any non-default extra-env runs |
+| `envs/<env>/...` | every `(example, <env>)` combination CI runs, whether `<env>` is that example's default or an extra-env override |
+| `whirl`, `docker/...`, `docker-compose.yaml`, root `.whirl.env` | **CORE** — affects all examples; a human picks the scope |
+| anything else (`*.md`, `.claude/...`, `README`, logos) | no CI impact |
+
+Both indexes (default from each `.whirl.env`, extra from the workflow) are built
+dynamically, so the mapping stays correct as examples are added, re-pointed, or as
+extra-env jobs are added/removed. Non-default combinations are tagged
+`NON-default` in the output and produce `./whirl -x <example> ci -e <env>` commands.
+
+## Workflow
+
+### 1. Identify the CI runs
+
+Run the bundled script from the repo root:
+
+```bash
+.claude/skills/verify-ci-impact/scripts/ci_impact.sh
+```
+
+It inspects committed-on-branch changes (vs `master`), staged, unstaged, and
+untracked files, then prints: the changed areas, any CORE change, the examples to
+verify (with the reason each was selected), and the exact `./whirl -x <example> ci`
+commands. Pass `--base <ref>` to diff against a different branch.
+
+Read the output and relay it to the user as a short plan — which examples, and why
+each one was selected. Don't just paste the raw output; summarize it.
+
+### 2. Handle the edge cases before asking
+
+- **CORE change** — the script does not expand this to "run everything" because
+  that can be 19 Docker runs. Surface it and propose a representative subset (the
+  script suggests one covering S3/API, Spark, dbt, DB+SFTP, and just-airflow),
+  then let the user decide subset vs. all.
+- **Excluded-from-CI examples** — some examples are excluded from the GitHub
+  Actions matrix (memory limits, no default DAG, or a separate job): the script
+  tags these with a `[NOTE: excluded from GitHub CI matrix]`. They can still be
+  run locally, but flag that they need more resources / manual attention and may
+  not be part of normal CI.
+- **No impact** — if only docs/`.claude/` changed, tell the user no CI run is
+  needed and stop. Don't run anything.
+
+### 3. Ask permission
+
+Present the concrete command list and ask the user to confirm before running.
+Make the cost visible — note how many runs and that each one builds/starts Docker.
+If there are several, ask whether they want all of them, a subset, or to skip.
+
+Only proceed with the runs the user explicitly approves.
+
+### 4. Run the approved CI checks
+
+Run each approved combination in CI mode from the repo root, using the exact
+command the script printed — default-env runs are `./whirl -x <example> ci`, and
+non-default combinations include the env override:
+
+```bash
+./whirl -x <example> ci            # default env
+./whirl -x <example> ci -e <env>   # non-default env combination
+```
+
+CI mode is headless: it starts the containers, triggers the default DAG, waits for
+completion, and tears down. Run them one at a time (they are resource-heavy and
+parallel Docker stacks contend for ports/memory). After each run, report whether
+the DAG succeeded; if one fails, surface the failure and stop before continuing to
+the next unless the user wants to push on.
+
+### 5. Summarize
+
+Report which examples passed, which failed, and which were skipped — so the user
+knows exactly what was and wasn't verified before they commit.

--- a/.claude/skills/verify-ci-impact/scripts/ci_impact.sh
+++ b/.claude/skills/verify-ci-impact/scripts/ci_impact.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+#
+# ci_impact.sh - Work out which whirl example/environment combinations need a CI
+# run based on the files that changed on this branch / in the working tree.
+#
+# An example is normally verified against its DEFAULT environment (the one in its
+# own .whirl.env). But the GitHub Actions workflow also runs a few examples against
+# NON-DEFAULT environments via `whirl ci -e <env>` (separate "extra-env" jobs).
+# Those (example, env) combinations are parsed straight from the workflow so this
+# script stays in sync, and they are verified too when the example OR that env
+# changes.
+#
+# The mapping rules:
+#   examples/<name>/...        -> run <name> against every env CI runs it with
+#                                 (its default env + any non-default extra-env runs)
+#   envs/<env>/...             -> run every (example, <env>) combination CI runs,
+#                                 whether <env> is that example's default or extra
+#   whirl | docker/ |          -> CORE change: affects every example. We do NOT
+#   docker-compose.yaml |         expand this to "run everything" automatically;
+#   ./.whirl.env (repo root)      we flag it so a human decides the scope.
+#   everything else            -> no CI impact (docs, .claude/, logos, READMEs)
+#
+# Usage:
+#   ci_impact.sh [--base <ref>]
+#     --base <ref>   git ref to diff committed branch work against (default: master)
+#
+# Output is a human-readable plan plus ready-to-run commands. It NEVER runs CI
+# itself - selecting and running are deliberately separate steps.
+
+set -euo pipefail
+
+BASE="master"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base) BASE="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+WORKFLOW=".github/workflows/whirl-ci.yml"
+
+# ---------------------------------------------------------------------------
+# 1. Collect changed files: committed-on-branch + uncommitted + untracked.
+# ---------------------------------------------------------------------------
+changed="$(
+  {
+    # committed work that is on this branch but not on the base
+    if git rev-parse --verify --quiet "$BASE" >/dev/null; then
+      git diff --name-only "$(git merge-base HEAD "$BASE" 2>/dev/null || echo "$BASE")...HEAD" 2>/dev/null || true
+    fi
+    # staged + unstaged + untracked, relative to repo root
+    git status --porcelain --untracked-files=all | sed 's/^...//' | sed 's/.* -> //'
+  } | sed 's#^"##; s#"$##' | sort -u | grep -v '^$' || true
+)"
+
+if [ -z "$changed" ]; then
+  echo "No changed files detected (base: $BASE). Nothing to verify."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Build the (example, env) run combinations CI knows about.
+#    EXAMPLE_ENV[example]   = the example's default environment ("" if unknown)
+#    ENV_EXAMPLES[env]      = examples that run with that env (default OR extra)
+#    EXAMPLE_ENVS[example]  = envs that example runs with (default + extras)
+# ---------------------------------------------------------------------------
+declare -A EXAMPLE_ENV
+for dir in examples/*/; do
+  name="$(basename "$dir")"
+  env=""
+  if [ -f "${dir}.whirl.env" ]; then
+    env="$(grep -E '^WHIRL_ENVIRONMENT=' "${dir}.whirl.env" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '[:space:]')"
+  fi
+  EXAMPLE_ENV["$name"]="$env"
+done
+
+declare -A ENV_EXAMPLES
+declare -A EXAMPLE_ENVS
+add_pair() {  # example env
+  local ex="$1" env="$2"
+  [ -z "$env" ] && return
+  case " ${EXAMPLE_ENVS[$ex]:-} " in *" $env "*) ;; *) EXAMPLE_ENVS[$ex]="${EXAMPLE_ENVS[$ex]:-} $env" ;; esac
+  case " ${ENV_EXAMPLES[$env]:-} " in *" $ex "*) ;; *) ENV_EXAMPLES[$env]="${ENV_EXAMPLES[$env]:-} $ex" ;; esac
+}
+
+# Default combinations: each example with the env from its own .whirl.env.
+for ex in "${!EXAMPLE_ENV[@]}"; do
+  add_pair "$ex" "${EXAMPLE_ENV[$ex]}"
+done
+
+# Extra (non-default) combinations: parse `whirl ci -e <env>` jobs from the
+# workflow. The example comes from an inline `-x <example>` if present, otherwise
+# from the job's `working-directory: ./examples/<example>`.
+EXTRA_PAIRS="$(
+  awk '
+    /working-directory:[[:space:]]*\.\/examples\// {
+      wd=$0; sub(/.*\/examples\//,"",wd); sub(/[\/[:space:]]*$/,"",wd)
+    }
+    /whirl/ && /[[:space:]]ci([[:space:]]|$)/ && /[[:space:]]-e[[:space:]]/ {
+      ex=wd
+      if (match($0,/-x[[:space:]]+[A-Za-z0-9._-]+/)) { ex=substr($0,RSTART,RLENGTH); sub(/-x[[:space:]]+/,"",ex) }
+      env=""
+      if (match($0,/-e[[:space:]]+[A-Za-z0-9._-]+/)) { env=substr($0,RSTART,RLENGTH); sub(/-e[[:space:]]+/,"",env) }
+      if (ex!="" && env!="") print ex"|"env
+    }
+  ' "$WORKFLOW" 2>/dev/null | sort -u
+)"
+while IFS= read -r p; do
+  [ -z "$p" ] && continue
+  add_pair "${p%%|*}" "${p##*|}"
+done <<< "$EXTRA_PAIRS"
+
+# Examples excluded from the GitHub Actions DEFAULT matrix (parsed from the
+# workflow so this stays in sync). These still run locally but the default-env CI
+# matrix skips them - usually memory limits or a separate job - so we surface them
+# as caveats on their default-env run.
+EXCLUDED="$(grep -hoE 'example(_dir)?: (\./examples/)?[a-z0-9-]+' "$WORKFLOW" 2>/dev/null \
+  | sed -E 's#.*[:/] *##' | sort -u || true)"
+is_excluded() { echo "$EXCLUDED" | grep -qx "$1"; }
+
+# ---------------------------------------------------------------------------
+# 3. Classify changed files into a set of (example, env) runs with reasons.
+#    Run set is keyed "example|env"; env "" means "default, env unknown".
+# ---------------------------------------------------------------------------
+declare -A RUN_REASON
+CORE_FILES=""
+IGNORED=""
+
+add_run() {  # key reason
+  local key="$1" reason="$2"
+  if [ -n "${RUN_REASON[$key]:-}" ]; then
+    case "${RUN_REASON[$key]}" in *"$reason"*) ;; *) RUN_REASON[$key]="${RUN_REASON[$key]}; $reason" ;; esac
+  else
+    RUN_REASON[$key]="$reason"
+  fi
+}
+
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    examples/*/*|examples/*)
+      ex="$(echo "$f" | cut -d/ -f2)"
+      [ -n "${EXAMPLE_ENV[$ex]+x}" ] || continue   # only real example dirs
+      if [ -n "${EXAMPLE_ENVS[$ex]:-}" ]; then
+        for env in ${EXAMPLE_ENVS[$ex]}; do
+          add_run "$ex|$env" "own files changed"
+        done
+      else
+        add_run "$ex|" "own files changed (env unknown)"
+      fi
+      ;;
+    envs/*/*|envs/*)
+      env="$(echo "$f" | cut -d/ -f2)"
+      for ex in ${ENV_EXAMPLES[$env]:-}; do
+        add_run "$ex|$env" "uses env '$env' (changed)"
+      done
+      ;;
+    whirl|docker/*|docker-compose.yaml|.whirl.env)
+      CORE_FILES="${CORE_FILES}  - $f"$'\n'
+      ;;
+    *)
+      IGNORED="${IGNORED}  - $f"$'\n'
+      ;;
+  esac
+done <<< "$changed"
+
+# ---------------------------------------------------------------------------
+# 4. Report.
+# ---------------------------------------------------------------------------
+file_count="$(echo "$changed" | grep -c '^' || true)"
+echo "== Changed areas (base: $BASE, ${file_count} files) =="
+echo "$changed" \
+  | sed -E 's#^(examples/[^/]+)/.*#\1/#; s#^(envs/[^/]+)/.*#\1/#' \
+  | sort | uniq -c \
+  | sed -E 's/^ *([0-9]+) (.*)$/  \2  (\1 file(s))/'
+echo
+
+if [ -n "$CORE_FILES" ]; then
+  echo "== CORE change detected =="
+  echo "These files affect ALL examples:"
+  printf '%s' "$CORE_FILES"
+  echo "A human should decide scope: run a representative subset, or all examples."
+  echo "Representative subset suggestion: api-to-s3 (S3+API), spark-s3-to-postgres (Spark),"
+  echo "dbt-example (dbt), sftp-mysql-example (DB+SFTP), airflow-cluster-policy (just-airflow)."
+  echo
+fi
+
+if [ ${#RUN_REASON[@]} -eq 0 ]; then
+  if [ -z "$CORE_FILES" ]; then
+    echo "== No example/env combinations need a CI run =="
+    echo "Only non-functional files changed (docs, .claude/, etc.)."
+  fi
+else
+  echo "== Example/env combinations to verify in CI =="
+  for key in $(printf '%s\n' "${!RUN_REASON[@]}" | sort); do
+    ex="${key%%|*}"; env="${key#*|}"
+    default="${EXAMPLE_ENV[$ex]:-}"
+    note=""
+    if [ -z "$env" ]; then
+      envlabel="default env"
+    elif [ "$env" = "$default" ]; then
+      envlabel="env: $env (default)"
+      is_excluded "$ex" && note="  [NOTE: excluded from GitHub CI matrix - verify locally]"
+    else
+      envlabel="env: $env (NON-default)"
+    fi
+    printf '  %-26s %-30s %s%s\n' "$ex" "$envlabel" "(${RUN_REASON[$key]})" "$note"
+  done
+  echo
+  echo "== Commands (run from repo root) =="
+  for key in $(printf '%s\n' "${!RUN_REASON[@]}" | sort); do
+    ex="${key%%|*}"; env="${key#*|}"
+    default="${EXAMPLE_ENV[$ex]:-}"
+    if [ -z "$env" ] || [ "$env" = "$default" ]; then
+      echo "  ./whirl -x $ex ci"
+    else
+      echo "  ./whirl -x $ex ci -e $env"
+    fi
+  done
+fi
+
+if [ -n "$IGNORED" ]; then
+  echo
+  echo "== Ignored (no CI impact) =="
+  printf '%s' "$IGNORED"
+fi

--- a/.claude/skills/version-bumper/SKILL.md
+++ b/.claude/skills/version-bumper/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: version-bumper
+description: Bump the Airflow or Python version across all project files. Use when the user wants to update AIRFLOW_VERSION or PYTHON_VERSION.
+argument-hint: "[airflow|python] <new-version>"
+disable-model-invocation: false
+---
+
+Bump a version across all relevant files in the whirl project.
+
+## Instructions
+
+The user will specify which version to bump (`airflow` or `python`) and the new version number.
+
+If the version type or target version is unclear, ask the user before proceeding.
+
+## File types to search
+
+The version string appears as a hardcoded literal (not a shell variable reference like `${AIRFLOW_VERSION}`) in these file types:
+
+- `**/.whirl.env` — as `AIRFLOW_VERSION=<version>` or `PYTHON_VERSION=<version>`
+- `**/Dockerfile` and `**/Dockerfile.*` — as `ARG AIRFLOW_VERSION=<version>` or `ARG PYTHON_VERSION=<version>`
+- `**/*.yml` — as `airflow_version: ["<version>"]` or in `python_version: [...]` lists
+- `CLAUDE.md` — as prose references to the current version
+
+## Steps
+
+1. **Discover the current version** by searching for the literal version pattern across the relevant file types:
+   ```
+   # For AIRFLOW_VERSION
+   grep -rn "AIRFLOW_VERSION=[0-9]" --include="*.env" --include="Dockerfile*" .
+   grep -rn "airflow_version:" --include="*.yml" .
+   grep -rn "AIRFLOW_VERSION" CLAUDE.md
+
+   # For PYTHON_VERSION
+   grep -rn "PYTHON_VERSION=[0-9]" --include="*.env" --include="Dockerfile*" .
+   grep -rn "python_version:" --include="*.yml" .
+   ```
+   This reveals the current version and every file that needs updating.
+
+2. **Exclude false positives** — skip matches where the version is a shell variable reference (e.g. `${AIRFLOW_VERSION}`) or a minimum-version guard (`MINIMAL_AIRFLOW_VERSION`). These must not be changed.
+
+3. **Edit each matched file** using the Edit tool, replacing the old version string with the new one. Use `replace_all: true` for files where the string appears multiple times (e.g. Dockerfiles with two `ARG` lines, CI workflows with multiple matrix blocks).
+
+4. **Verify** by re-running the discovery grep from step 1 and confirming no occurrences of the old version remain:
+   ```
+   grep -rn "<old-version>" --include="*.env" --include="Dockerfile*" --include="*.yml" .
+   grep -n "<old-version>" CLAUDE.md
+   ```
+
+5. **Report** which files were changed and the new version value in each.
+
+6. **Check docker-compose changes** against the official Airflow release (Airflow version bumps only):
+
+   Fetch the official docker-compose for the new version:
+   ```
+   curl -Lf 'https://airflow.apache.org/docs/apache-airflow/<NEW_VERSION>/docker-compose.yaml'
+   ```
+
+   Then read each `envs/*/docker-compose.yml` in this repo and compare the Airflow service definitions (api-server, scheduler, dagprocessor, triggerer) against the official file. Focus on:
+   - New or removed environment variables in the `x-airflow-common` block
+   - New or removed volume mounts
+   - Changed healthcheck commands or intervals
+   - Changed service dependencies (`depends_on`)
+   - Changed ports or commands
+
+   **Known intentional differences to ignore** — these are whirl-specific and must NOT be "fixed":
+
+   | Topic | Official docker-compose | Whirl envs |
+   |-------|------------------------|------------|
+   | Image | `apache/airflow:<version>` | `docker-whirl-airflow:py-${PYTHON_VERSION}-local` |
+   | Port | api-server on `8080` | api-server on `5000` (with `-p 5000` command arg) |
+   | Executor | `CeleryExecutor` with worker + Redis | No executor set (uses LocalExecutor via `.whirl.env`) |
+   | Env vars (official only) | `AIRFLOW__CORE__EXECUTOR`, `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN`, `AIRFLOW__CELERY__*`, `AIRFLOW__CORE__FERNET_KEY`, `AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION`, `AIRFLOW__CORE__LOAD_EXAMPLES`, `AIRFLOW_CONFIG`, `_PIP_ADDITIONAL_REQUIREMENTS` | Sourced from `.whirl.env` via `env_file` |
+   | Env vars (whirl only) | — | `WHIRL_SETUP_FOLDER`, `AIRFLOW__FAB__AUTH_BACKENDS`, `AIRFLOW__API_AUTH__JWT_SECRET` |
+   | Volume mounts (official only) | `logs/`, `config/`, `plugins/` directories | Not mounted |
+   | Volume mounts (whirl only) | — | `whirl.setup.d` → `env.d/` and `dag.d/`, `src/` + `setup.py` → `/opt/airflow/custom/`, named build volumes per service |
+   | Init service | `airflow-init` for DB migration + user creation | Handled by whirl entrypoint scripts |
+   | Restart policy | `restart: always` | Not set |
+   | User | `"${AIRFLOW_UID:-50000}:0"` | Not set |
+
+   **Report any differences that are NOT in the table above** — those may indicate new config or behaviour in the Airflow release that should be adopted in the whirl envs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Whirl is a Docker-based local development and testing tool for Apache Airflow workflows. It spins up Airflow with supporting services (S3, databases, Spark, etc.) in Docker containers, allowing developers to run DAGs locally with volume mounts for live code editing.
+
+## Commands
+
+```bash
+# Start whirl with current directory as DAG folder
+whirl -e <environment> [start]
+
+# Start with a specific example
+whirl -x <example> -e <environment>
+
+# Run in CI mode (headless, automated DAG execution)
+whirl ci
+whirl -x <example> ci
+
+# Stop containers
+whirl stop
+
+# View logs
+whirl -l
+```
+
+The Airflow UI is available at http://localhost:5000 (admin/admin).
+
+## Architecture
+
+### Core Components
+
+- **`whirl`** - Main Bash script (~500 lines) that orchestrates Docker Compose, environment loading, and DAG lifecycle
+- **`docker/airflow-python/`** - Airflow Docker image (Dockerfile + entrypoint.sh)
+- **`envs/`** - Environment definitions (Docker Compose + setup scripts)
+- **`examples/`** - Example DAG projects
+
+### Environment Loading Priority (lowest to highest)
+
+1. `~/.whirl.env`
+2. `${SCRIPT_DIR}/.whirl.env` (repository root)
+3. `${ENVIRONMENT_FOLDER}/.whirl.env`
+4. `${DAG_FOLDER}/.whirl.env`
+5. Command-line environment variables
+
+### Key Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `WHIRL_ENVIRONMENT` | Which environment to use (directory name in `envs/`) |
+| `AIRFLOW_VERSION` | Airflow version (currently 3.2.1) |
+| `PYTHON_VERSION` | Python version (3.10 or 3.13) |
+| `DAG_FOLDER` | Path to DAG code (mounted into container) |
+| `ENVIRONMENT_FOLDER` | Path to environment definition |
+
+### Setup Scripts
+
+- **`whirl.setup.d/*.sh`** - Executed inside container on startup (install packages, configure connections)
+- **`compose.setup.d/*.sh`** - Executed on host before Docker Compose starts
+
+Scripts run in alphabetical order. Environment scripts run before DAG scripts.
+
+## Skills
+
+This repo provides project skills under `.claude/skills/`. Prefer invoking them over performing the equivalent steps manually:
+
+- **create-example** — scaffold a new example in `examples/`. Use for "create/add/scaffold an example".
+- **create-environment** — scaffold a new Docker Compose environment in `envs/`. Use for "create/add an environment". Also invoked by `create-example` when a custom environment is needed.
+- **version-bumper** — bump `AIRFLOW_VERSION` or `PYTHON_VERSION` across all project files (including the version references in this file).
+- **verify-ci-impact** — before committing, map changed files to the examples that need a CI run, then run them after confirming. Use for "what should I test before committing", "which examples does this change affect".
+
+## Agents
+
+Project subagents live under `.claude/agents/`:
+
+- **ci-verifier** — runs the impacted examples in CI mode outside the current session (in the background or as a team member), using the `verify-ci-impact` skill to find what to run. Delegate to it for "verify my changes in the background" or as the verification stage of an agent team. It runs the CI checks autonomously (dispatch = authorization) and returns a pass/fail report.
+
+## Available Environments
+
+Key environments in `envs/`:
+- `just-airflow` - Minimal Airflow only
+- `api-s3-dataset` - Airflow + S3 + PostgreSQL + MockServer
+- `postgres-s3-spark` - Data pipeline with Spark
+- `api-python-s3-k8s` - Kubernetes job operators
+- `dbt-example` - DBT integration
+
+## CI/Testing
+
+The project uses GitHub Actions with shellcheck for linting. CI runs examples across Python 3.10/3.13 and Airflow 3.2.1.
+
+To test locally:
+```bash
+# Run CI mode for any example
+whirl -x api-to-s3 ci
+
+# Run from example directory
+cd examples/api-to-s3 && ../../whirl ci
+```
+
+Requires `jq` for CI mode JSON parsing.
+
+## Adding New Examples/Environments
+
+### New Example
+Use the **create-example** skill — it gathers requirements interactively and generates all files in `examples/<name>/`.
+
+### New Environment
+Use the **create-environment** skill — it gathers requirements interactively and generates all files in `envs/<name>/`.


### PR DESCRIPTION
Adds Claude Code tooling for working in this repo: a set of project skills, a CI-verification subagent, plugin packaging, and a `CLAUDE.md` guide.

## What's included
- **`CLAUDE.md`** — project overview, commands, architecture, environment-loading priority, and pointers to the skills/agents.
- **Skills** (`.claude/skills/`):
  - `create-example` — scaffold a new example in `examples/`.
  - `create-environment` — scaffold a new Docker Compose environment in `envs/`.
  - `version-bumper` — bump `AIRFLOW_VERSION` / `PYTHON_VERSION` across all project files.
  - `verify-ci-impact` — map changed files to the examples that need a CI run (includes `scripts/ci_impact.sh`).
- **Agent** (`.claude/agents/ci-verifier.md`) — runs the impacted examples in CI mode outside the main session and returns a pass/fail report. Uses the `verify-ci-impact` skill to decide what to run.
- **Plugin packaging** (`.claude/plugins/whirl/`) — bundles the skills as a `whirl` plugin.

## Notes
- 12 files, all under `.claude/` plus `CLAUDE.md`; no changes to `whirl`, environments, or examples.
- The `ci-verifier` agent was exercised end-to-end while reviewing other branches and correctly scoped impacted examples, ran them in CI mode, and reported results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)