### PR TITLE
Add DAG parsing & validation test suite (Plan A)

### DIFF
--- a/.github/workflows/whirl-ci.yml
+++ b/.github/workflows/whirl-ci.yml
@@ -25,6 +25,11 @@ jobs:
         run: uv python install 3.13
       - name: Sync test dependencies
         run: uv sync --group test
+      - name: Install example custom packages
+        # Two examples import local packages; install them so their DAGs validate.
+        run: |
+          mkdir -p /tmp/custom_build
+          uv pip install ./examples/airflow-deferrable-operator-custom ./examples/airflow-timetable/whirl.setup.d/plugins
       - name: Run pytest
         run: uv run pytest -q
 

--- a/tests/test_dag_validation.py
+++ b/tests/test_dag_validation.py
@@ -1,0 +1,69 @@
+"""Parse-and-validate every example DAG.
+
+For each ``examples/*/dag.py`` this builds an Airflow ``DagBag`` and asserts the
+folder parses with no import errors and yields at least one DAG. ``DagBag`` also
+enforces unique task ids and rejects cycles (both surface as import errors), so
+structural validation comes for free.
+
+Examples needing packages outside the curated ``test`` dependency group are
+skipped with an explicit reason, so skips stay visible and a newly added example
+with missing deps fails loudly rather than passing silently.
+"""
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+from conftest import example_dirs_with_dag
+
+# whirl's CI mode auto-detects the dag_id from dag.py with this pattern
+# (see the `whirl` script). Keep the suite honest about that contract.
+DAG_ID_RE = re.compile(r"""dag_id=['"](.+?)['"]""")
+
+# Examples whose dag.py imports packages we deliberately do not install in the
+# curated `test` group (heavy / niche). Skipped with a clear reason.
+SKIP_PARSE = {
+    "dbt-example": "requires the airflow_dbt_python package",
+    "dbt-spark-example": "requires the airflow_dbt_python package",
+    "spark-delta-sharing": "requires the delta_sharing package",
+}
+
+# Examples that import a local package installed from the example itself.
+# name -> (importable module, path passed to `uv pip install` for validation).
+CUSTOM_PKG_EXAMPLES = {
+    "airflow-deferrable-operator-custom": ("custom", "examples/airflow-deferrable-operator-custom"),
+    "airflow-timetable": ("custom_plugins", "examples/airflow-timetable/whirl.setup.d/plugins"),
+}
+
+EXAMPLES = example_dirs_with_dag()
+
+
+@pytest.mark.dag_validation
+@pytest.mark.parametrize("example_dir", EXAMPLES, ids=lambda p: p.name)
+def test_example_dag_parses(example_dir: Path):
+    name = example_dir.name
+    if name in SKIP_PARSE:
+        pytest.skip(f"{name}: {SKIP_PARSE[name]}")
+    if name in CUSTOM_PKG_EXAMPLES:
+        module, path = CUSTOM_PKG_EXAMPLES[name]
+        if importlib.util.find_spec(module) is None:
+            pytest.skip(f"{name}: install its package first — `uv pip install ./{path}`")
+
+    # Imported lazily so the airflow-free suites don't require the `test` group.
+    from airflow.models.dagbag import DagBag
+
+    bag = DagBag(dag_folder=str(example_dir), include_examples=False, safe_mode=True)
+    assert bag.import_errors == {}, f"import errors in {name}: {bag.import_errors}"
+    assert len(bag.dags) >= 1, f"no DAGs found in {name}"
+
+
+@pytest.mark.dag_validation
+@pytest.mark.parametrize("example_dir", EXAMPLES, ids=lambda p: p.name)
+def test_dag_id_is_whirl_detectable(example_dir: Path):
+    """Every example's dag_id must be greppable the way `whirl ci` detects it."""
+    text = (example_dir / "dag.py").read_text()
+    assert DAG_ID_RE.search(text), (
+        f"whirl could not auto-detect a dag_id in {example_dir.name}/dag.py"
+    )


### PR DESCRIPTION
Plan A of **CLAUDE_IMPROVEMENTS.md #4**. **Stacked on #108** (uv test foundation) — base is `improve/testing-foundation`, so this diff is just the DAG suite. Review/merge #108 first.

## What's here
- **`tests/test_dag_validation.py`** — for every `examples/*/dag.py`, builds an Airflow `DagBag` and asserts it parses with **no import errors** and yields **≥1 DAG** (DagBag also enforces unique task ids / rejects cycles). A second parametrized test asserts each `dag_id` stays greppable the way `whirl ci` auto-detects it.
- **Explicit `SKIP_PARSE` map** for examples needing packages outside the curated `test` group (`dbt-example`, `dbt-spark-example` → `airflow_dbt_python`; `spark-delta-sharing` → `delta_sharing`). Skips are visible, and a newly added example with missing deps **fails loudly** rather than passing silently.
- **Custom-package examples** (`airflow-deferrable-operator-custom` → `custom`, `airflow-timetable` → `custom_plugins`) are validated after installing their local packages; the CI `unit-tests` job installs them (`mkdir /tmp/custom_build` for the timetable plugin's hardcoded `egg_base`) before pytest.

## Validation
Local run on Python 3.13: **31 passed, 3 skipped** (the 3 documented heavy/niche examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)