### PR TITLE
Add setup-script checks: shellcheck-all + pytest conventions (Plan B)

### DIFF
--- a/.github/workflows/whirl-ci.yml
+++ b/.github/workflows/whirl-ci.yml
@@ -15,6 +15,14 @@ jobs:
         with:
           # https://github.com/koalaman/shellcheck#how-to-use
           cli-args: "-x whirl"
+      - name: shellcheck setup scripts
+        # Lint every setup script (gated at warning severity; info-level quoting
+        # noise is tracked separately). The main `whirl` script is linted above.
+        run: |
+          shellcheck --severity=warning $(find envs examples -type f \
+            \( -path '*/whirl.setup.d/*.sh' \
+            -o -path '*/compose.setup.d/*.sh' \
+            -o -path '*/compose.teardown.d/*.sh' \) | sort)
 
   unit-tests: # Fast, Docker-free pytest suite (DAG parsing + setup-script checks)
     runs-on: ubuntu-latest

--- a/envs/airflow-s3-logging/whirl.setup.d/01_add_connection_s3.sh
+++ b/envs/airflow-s3-logging/whirl.setup.d/01_add_connection_s3.sh
@@ -22,7 +22,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "================================"
 echo "== Create S3 Bucket ==========="
 echo "================================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/api-python-s3-k8s/compose.setup.d/02_clean_local_data_share.sh
+++ b/envs/api-python-s3-k8s/compose.setup.d/02_clean_local_data_share.sh
@@ -4,7 +4,7 @@ function empty_local_data_share_dir() {
     echo "=================================="
     echo "== Cleanup local data mount dir =="
     echo "=================================="
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     DATA_MOUNT_DIR="${SCRIPT_DIR}/../.local-data-share"
 
     if [ "$(ls -A ${DATA_MOUNT_DIR})" ]; then

--- a/envs/api-python-s3-k8s/whirl.setup.d/01_add_connection_s3server.sh
+++ b/envs/api-python-s3-k8s/whirl.setup.d/01_add_connection_s3server.sh
@@ -23,7 +23,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "================================"
 echo "== Create S3 Bucket ==========="
 echo "================================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/api-python-s3/whirl.setup.d/01_add_connection_s3server.sh
+++ b/envs/api-python-s3/whirl.setup.d/01_add_connection_s3server.sh
@@ -23,7 +23,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "================================"
 echo "== Create S3 Bucket ==========="
 echo "================================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/api-s3-dataset/whirl.setup.d/01_add_connection_api.sh
+++ b/envs/api-s3-dataset/whirl.setup.d/01_add_connection_api.sh
@@ -23,7 +23,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "================================"
 echo "== Create S3 Bucket ==========="
 echo "================================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/dbt-example/compose.setup.d/01_clean_pg_data_dir.sh
+++ b/envs/dbt-example/compose.setup.d/01_clean_pg_data_dir.sh
@@ -4,7 +4,7 @@ function empty_data_dir() {
     echo "================================"
     echo "== Cleanup local PG mount dir =="
     echo "================================"
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     PG_DATA_DIR="${SCRIPT_DIR}/../.pgdata"
 
     if [ "$(ls -A ${PG_DATA_DIR})" ]; then

--- a/envs/dbt-example/whirl.setup.d/01_add_connection_s3.sh
+++ b/envs/dbt-example/whirl.setup.d/01_add_connection_s3.sh
@@ -15,7 +15,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "======================"
 echo "== Create S3 Bucket =="
 echo "======================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/dbt-example/whirl.setup.d/03_add_spark_config.sh
+++ b/envs/dbt-example/whirl.setup.d/03_add_spark_config.sh
@@ -26,7 +26,8 @@ airflow connections add spark_default \
     --conn-host "spark://sparkmaster:7077" \
     --conn-extra "{\"queue\": \"root.default\", \"deploy-mode\": \"client\"}"
 
-export SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
+export SPARK_HOME
+SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
 echo "-------------------------------"
 echo "SPARK_HOME set to ${SPARK_HOME}"
 echo "-------------------------------"

--- a/envs/postgres-s3-external-spark/whirl.setup.d/01_add_connection_s3.sh
+++ b/envs/postgres-s3-external-spark/whirl.setup.d/01_add_connection_s3.sh
@@ -15,7 +15,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "======================"
 echo "== Create S3 Bucket =="
 echo "======================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/postgres-s3-external-spark/whirl.setup.d/03_add_spark_config.sh
+++ b/envs/postgres-s3-external-spark/whirl.setup.d/03_add_spark_config.sh
@@ -26,7 +26,8 @@ airflow connections add spark_default \
     --conn-host "spark://sparkmaster:7077" \
     --conn-extra "{\"queue\": \"root.default\", \"deploy-mode\": \"client\"}"
 
-export SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
+export SPARK_HOME
+SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
 echo "-------------------------------"
 echo "SPARK_HOME set to ${SPARK_HOME}"
 echo "-------------------------------"

--- a/envs/postgres-s3-spark/whirl.setup.d/01_add_connection_s3.sh
+++ b/envs/postgres-s3-spark/whirl.setup.d/01_add_connection_s3.sh
@@ -15,7 +15,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "======================"
 echo "== Create S3 Bucket =="
 echo "======================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/postgres-s3-spark/whirl.setup.d/03_add_spark_config.sh
+++ b/envs/postgres-s3-spark/whirl.setup.d/03_add_spark_config.sh
@@ -25,7 +25,8 @@ airflow connections add spark_default \
     --conn-host local \
     --conn-extra "{\"queue\": \"root.default\"}"
 
-export SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
+export SPARK_HOME
+SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
 echo "-------------------------------"
 echo "SPARK_HOME set to ${SPARK_HOME}"
 echo "-------------------------------"

--- a/envs/s3-external-spark-hive/compose.setup.d/02_clean_s3_mount_dir.sh
+++ b/envs/s3-external-spark-hive/compose.setup.d/02_clean_s3_mount_dir.sh
@@ -4,7 +4,7 @@ function empty_s3_dir() {
     echo "================================"
     echo "== Cleanup local S3 mount dir =="
     echo "================================"
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     S3_MOUNT_DIR="${SCRIPT_DIR}/../.s3-mount"
 
     if [ "$(ls -A ${S3_MOUNT_DIR})" ]; then

--- a/envs/s3-external-spark-hive/whirl.setup.d/01_add_connection_s3.sh
+++ b/envs/s3-external-spark-hive/whirl.setup.d/01_add_connection_s3.sh
@@ -15,7 +15,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "======================"
 echo "== Create S3 Bucket =="
 echo "======================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/s3-external-spark-hive/whirl.setup.d/03_add_spark_config.sh
+++ b/envs/s3-external-spark-hive/whirl.setup.d/03_add_spark_config.sh
@@ -27,7 +27,8 @@ airflow connections add spark_default \
     --conn-host "spark://sparkmaster:7077" \
     --conn-extra "{\"queue\": \"root.default\", \"deploy-mode\": \"client\"}"
 
-export SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
+export SPARK_HOME
+SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
 echo "-------------------------------"
 echo "SPARK_HOME set to ${SPARK_HOME}"
 echo "-------------------------------"

--- a/envs/s3-spark-delta-sharing-minio/compose.setup.d/02_clean_s3_mount_dir.sh
+++ b/envs/s3-spark-delta-sharing-minio/compose.setup.d/02_clean_s3_mount_dir.sh
@@ -4,7 +4,7 @@ function empty_s3_dir() {
     echo "================================"
     echo "== Cleanup local S3 mount dir =="
     echo "================================"
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     S3_MOUNT_DIR="${SCRIPT_DIR}/../.s3-mount"
 
     if [ "$(ls -A ${S3_MOUNT_DIR})" ]; then

--- a/envs/s3-spark-delta-sharing-minio/whirl.setup.d/01_add_connection_s3.sh
+++ b/envs/s3-spark-delta-sharing-minio/whirl.setup.d/01_add_connection_s3.sh
@@ -14,7 +14,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "======================"
 echo "== Create S3 Bucket =="
 echo "======================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT}/minio/health/live)" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT}/minio/health/live)" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up on port ${AWS_PORT}..."
   sleep 2;
 done

--- a/envs/s3-spark-delta-sharing-minio/whirl.setup.d/02_add_spark_config.sh
+++ b/envs/s3-spark-delta-sharing-minio/whirl.setup.d/02_add_spark_config.sh
@@ -26,7 +26,8 @@ airflow connections add spark_default \
     --conn-host "spark://sparkmaster:7077" \
     --conn-extra "{\"queue\": \"root.default\", \"deploy-mode\": \"client\"}"
 
-export SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
+export SPARK_HOME
+SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
 echo "-------------------------------"
 echo "SPARK_HOME set to ${SPARK_HOME}"
 echo "-------------------------------"

--- a/envs/s3-spark-delta-sharing-riverbank/compose.setup.d/02_clean_s3_mount_dir.sh
+++ b/envs/s3-spark-delta-sharing-riverbank/compose.setup.d/02_clean_s3_mount_dir.sh
@@ -4,7 +4,7 @@ function empty_s3_dir() {
     echo "================================"
     echo "== Cleanup local S3 mount dir =="
     echo "================================"
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     S3_MOUNT_DIR="${SCRIPT_DIR}/../.s3-mount"
 
     if [ "$(ls -A ${S3_MOUNT_DIR})" ]; then

--- a/envs/s3-spark-delta-sharing-riverbank/compose.setup.d/03_clean_pg_data_dir.sh
+++ b/envs/s3-spark-delta-sharing-riverbank/compose.setup.d/03_clean_pg_data_dir.sh
@@ -4,7 +4,7 @@ function empty_data_dir() {
     echo "================================"
     echo "== Cleanup local PG mount dir =="
     echo "================================"
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     PG_DATA_DIR="${SCRIPT_DIR}/../.pgdata"
 
     if [ "$(ls -A ${PG_DATA_DIR})" ]; then

--- a/envs/s3-spark-delta-sharing-riverbank/whirl.setup.d/01_add_connection_s3.sh
+++ b/envs/s3-spark-delta-sharing-riverbank/whirl.setup.d/01_add_connection_s3.sh
@@ -22,7 +22,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "======================"
 echo "== Create S3 Bucket =="
 echo "======================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/s3-spark-delta-sharing-riverbank/whirl.setup.d/02_add_spark_config.sh
+++ b/envs/s3-spark-delta-sharing-riverbank/whirl.setup.d/02_add_spark_config.sh
@@ -26,7 +26,8 @@ airflow connections add spark_default \
     --conn-host "spark://sparkmaster:7077" \
     --conn-extra "{\"queue\": \"root.default\", \"deploy-mode\": \"client\"}"
 
-export SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
+export SPARK_HOME
+SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
 echo "-------------------------------"
 echo "SPARK_HOME set to ${SPARK_HOME}"
 echo "-------------------------------"

--- a/envs/s3-spark-delta-sharing/compose.setup.d/02_clean_s3_mount_dir.sh
+++ b/envs/s3-spark-delta-sharing/compose.setup.d/02_clean_s3_mount_dir.sh
@@ -4,7 +4,7 @@ function empty_s3_dir() {
     echo "================================"
     echo "== Cleanup local S3 mount dir =="
     echo "================================"
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     S3_MOUNT_DIR="${SCRIPT_DIR}/../.s3-mount"
 
     if [ "$(ls -A ${S3_MOUNT_DIR})" ]; then

--- a/envs/s3-spark-delta-sharing/whirl.setup.d/01_add_connection_s3.sh
+++ b/envs/s3-spark-delta-sharing/whirl.setup.d/01_add_connection_s3.sh
@@ -22,7 +22,7 @@ aws configure set default.s3api.endpoint_url http://${AWS_SERVER}:${AWS_PORT}
 echo "======================"
 echo "== Create S3 Bucket =="
 echo "======================"
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://${AWS_SERVER}:${AWS_PORT})" != "200" ]]; do
   echo "Waiting for ${AWS_SERVER} to come up..."
   sleep 2;
 done

--- a/envs/s3-spark-delta-sharing/whirl.setup.d/02_add_spark_config.sh
+++ b/envs/s3-spark-delta-sharing/whirl.setup.d/02_add_spark_config.sh
@@ -26,7 +26,8 @@ airflow connections add spark_default \
     --conn-host "spark://sparkmaster:7077" \
     --conn-extra "{\"queue\": \"root.default\", \"deploy-mode\": \"client\"}"
 
-export SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
+export SPARK_HOME
+SPARK_HOME=$(python ~/.local/bin/find_spark_home.py)
 echo "-------------------------------"
 echo "SPARK_HOME set to ${SPARK_HOME}"
 echo "-------------------------------"

--- a/examples/airflow-cluster-policy/whirl.setup.d/01_configure_cluster_policies.sh
+++ b/examples/airflow-cluster-policy/whirl.setup.d/01_configure_cluster_policies.sh
@@ -7,7 +7,7 @@ echo "========================"
 
 mkdir -p ${AIRFLOW_HOME}/config
 
-SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 echo "Configure dag policies from ${SCRIPT_DIR}/policies/dag_policy.py"
 cat ${SCRIPT_DIR}/policies/dag_policy.py > ${AIRFLOW_HOME}/config/airflow_local_settings.py

--- a/examples/dbt-example/compose.setup.d/02_clean_dbt_log.sh
+++ b/examples/dbt-example/compose.setup.d/02_clean_dbt_log.sh
@@ -4,7 +4,7 @@ function empty_log_dir() {
     echo "====================================="
     echo "== Cleanup local DBT log mount dir =="
     echo "====================================="
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     DBT_LOG_DIR="${SCRIPT_DIR}/../dbt/logs"
 
     if [ "$(ls -A ${DBT_LOG_DIR})" ]; then

--- a/examples/dbt-example/compose.teardown.d/01_show_dbt_log.sh
+++ b/examples/dbt-example/compose.teardown.d/01_show_dbt_log.sh
@@ -4,7 +4,7 @@ function show_logs() {
     echo "======================="
     echo "== Show dbt run logs =="
     echo "======================="
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     DBT_LOG_DIR="${SCRIPT_DIR}/../dbt/logs"
 
     if [ "$(ls -A ${DBT_LOG_DIR}/dbt.log)" ]; then

--- a/examples/dbt-example/whirl.setup.d/01_add_mockdata_to_s3.sh
+++ b/examples/dbt-example/whirl.setup.d/01_add_mockdata_to_s3.sh
@@ -6,4 +6,4 @@ echo "== Setup Mockdata in S3 =="
 echo "=========================="
 sudo apt-get update && sudo apt-get install -y unzip
 
-aws s3api put-object --bucket ${DBT_BUCKET} --key input/data/dbt/$(date "+%Y%m%d")/flights_data.zip --body /mock-data/flights_data.zip
+aws s3api put-object --bucket ${DBT_BUCKET} --key "input/data/dbt/$(date +%Y%m%d)/flights_data.zip" --body /mock-data/flights_data.zip

--- a/examples/dbt-spark-example/compose.setup.d/02_clean_dbt_log.sh
+++ b/examples/dbt-spark-example/compose.setup.d/02_clean_dbt_log.sh
@@ -4,7 +4,7 @@ function empty_log_dir() {
     echo "====================================="
     echo "== Cleanup local DBT log mount dir =="
     echo "====================================="
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     DBT_LOG_DIR="${SCRIPT_DIR}/../dbt/logs"
 
     if [ "$(ls -A ${DBT_LOG_DIR})" ]; then

--- a/examples/dbt-spark-example/compose.teardown.d/01_show_dbt_log.sh
+++ b/examples/dbt-spark-example/compose.teardown.d/01_show_dbt_log.sh
@@ -4,7 +4,7 @@ function show_logs() {
     echo "======================="
     echo "== Show dbt run logs =="
     echo "======================="
-    local SCRIPT_DIR=$( dirname ${BASH_SOURCE[0]} )
+    local SCRIPT_DIR; SCRIPT_DIR=$( dirname "${BASH_SOURCE[0]}" )
     DBT_LOG_DIR="${SCRIPT_DIR}/../dbt/logs"
 
     if [ "$(ls -A ${DBT_LOG_DIR}/dbt.log)" ]; then

--- a/examples/dbt-spark-example/whirl.setup.d/01_add_mockdata_to_s3.sh
+++ b/examples/dbt-spark-example/whirl.setup.d/01_add_mockdata_to_s3.sh
@@ -7,4 +7,4 @@ echo "=========================="
 sudo apt-get update && sudo apt-get install -y unzip
 
 aws s3api create-bucket --bucket ${DBT_BUCKET}
-aws s3api put-object --bucket ${DBT_BUCKET} --key input/data/dbt/$(date "+%Y%m%d")/flights_data.zip --body /mock-data/flights_data.zip
+aws s3api put-object --bucket ${DBT_BUCKET} --key "input/data/dbt/$(date +%Y%m%d)/flights_data.zip" --body /mock-data/flights_data.zip

--- a/examples/sftp-mysql-example/whirl.setup.d/01_cp_mock_data_to_sftp.sh
+++ b/examples/sftp-mysql-example/whirl.setup.d/01_cp_mock_data_to_sftp.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2044  # mock-data filenames are controlled and space-free
 set -e
 
 source /etc/airflow/functions/date_replacement.sh

--- a/examples/spark-delta-sharing/whirl.setup.d/01_add_mockdata_to_s3.sh
+++ b/examples/spark-delta-sharing/whirl.setup.d/01_add_mockdata_to_s3.sh
@@ -5,4 +5,4 @@ echo "=========================="
 echo "== Setup Mockdata in S3 =="
 echo "=========================="
 
-aws s3api put-object --bucket ${DEMO_BUCKET} --key input/data/demo/spark/$(date "+%Y%m%d")/data.json --body /mock-data/input.json
+aws s3api put-object --bucket ${DEMO_BUCKET} --key "input/data/demo/spark/$(date +%Y%m%d)/data.json" --body /mock-data/input.json

--- a/examples/spark-s3-to-hive/whirl.setup.d/01_add_mockdata_to_s3.sh
+++ b/examples/spark-s3-to-hive/whirl.setup.d/01_add_mockdata_to_s3.sh
@@ -5,4 +5,4 @@ echo "=========================="
 echo "== Setup Mockdata in S3 =="
 echo "=========================="
 
-aws s3api put-object --bucket ${DEMO_BUCKET} --key input/data/demo/spark/$(date "+%Y%m%d")/data.json --body /mock-data/input.json
+aws s3api put-object --bucket ${DEMO_BUCKET} --key "input/data/demo/spark/$(date +%Y%m%d)/data.json" --body /mock-data/input.json

--- a/examples/spark-s3-to-postgres/whirl.setup.d/01_add_mockdata_to_s3.sh
+++ b/examples/spark-s3-to-postgres/whirl.setup.d/01_add_mockdata_to_s3.sh
@@ -5,4 +5,4 @@ echo "=========================="
 echo "== Setup Mockdata in S3 =="
 echo "=========================="
 
-aws s3api put-object --bucket ${DEMO_BUCKET} --key input/data/demo/spark/$(date "+%Y%m%d")/data.json --body /mock-data/input.json
+aws s3api put-object --bucket ${DEMO_BUCKET} --key "input/data/demo/spark/$(date +%Y%m%d)/data.json" --body /mock-data/input.json

--- a/tests/test_setup_scripts.py
+++ b/tests/test_setup_scripts.py
@@ -1,0 +1,73 @@
+"""Structural/convention checks for whirl's bash setup scripts.
+
+These run with only ``pytest`` installed (no airflow). They lock in conventions
+that the end-to-end CI runs depend on but never assert directly:
+
+* every setup script is a ``#!/usr/bin/env bash`` script with the ``NN_name.sh``
+  ordering-prefix naming convention;
+* every ``whirl.setup.d`` script enables ``set -e`` near the top, so a failing
+  setup step aborts container startup instead of silently continuing.
+
+``compose.setup.d`` / ``compose.teardown.d`` scripts are *sourced* by the
+``whirl`` script (which already runs under ``set -e``), so the errexit check is
+scoped to ``whirl.setup.d`` only.
+"""
+
+import re
+
+import pytest
+
+from conftest import REPO_ROOT
+
+SETUP_ROOTS = (REPO_ROOT / "envs", REPO_ROOT / "examples")
+ALL_SETUP_DIRS = ("whirl.setup.d", "compose.setup.d", "compose.teardown.d")
+NAME_RE = re.compile(r"^\d{2,}_[a-z0-9_]+\.sh$")
+SET_E_RE = re.compile(r"^\s*set -e")
+
+
+def _collect(*subdirs):
+    scripts = []
+    for root in SETUP_ROOTS:
+        for sub in subdirs:
+            scripts.extend(root.glob(f"*/{sub}/*.sh"))
+    return sorted(scripts)
+
+
+ALL_SCRIPTS = _collect(*ALL_SETUP_DIRS)
+WHIRL_SETUP_SCRIPTS = _collect("whirl.setup.d")
+
+
+def _id(path):
+    return str(path.relative_to(REPO_ROOT))
+
+
+def test_setup_scripts_are_discovered():
+    # Guard against the glob silently matching nothing (which would make every
+    # parametrized check below vacuously pass).
+    assert len(ALL_SCRIPTS) >= 50
+
+
+@pytest.mark.setup_scripts
+@pytest.mark.parametrize("script", ALL_SCRIPTS, ids=_id)
+def test_has_bash_shebang(script):
+    first_line = script.read_text().splitlines()[0]
+    assert first_line == "#!/usr/bin/env bash", (
+        f"{_id(script)}: unexpected shebang {first_line!r}"
+    )
+
+
+@pytest.mark.setup_scripts
+@pytest.mark.parametrize("script", ALL_SCRIPTS, ids=_id)
+def test_filename_follows_ordering_convention(script):
+    assert NAME_RE.match(script.name), (
+        f"{script.name}: setup scripts must be named NN_lowercase_name.sh"
+    )
+
+
+@pytest.mark.setup_scripts
+@pytest.mark.parametrize("script", WHIRL_SETUP_SCRIPTS, ids=_id)
+def test_whirl_setup_scripts_enable_errexit(script):
+    head = script.read_text().splitlines()[:5]
+    assert any(SET_E_RE.match(line) for line in head), (
+        f"{_id(script)}: whirl.setup.d scripts must enable `set -e` near the top"
+    )


### PR DESCRIPTION
Plan B of **CLAUDE_IMPROVEMENTS.md #4**. **Stacked on #108** (uv test foundation) — base is `improve/testing-foundation`. Independent of Plan A (#109). Review/merge #108 first.

## What's here
**B1 — shellcheck fixes** so all setup scripts pass at warning severity:
- `SC1083`: `-w ''%{http_code}''` → `-w '%{http_code}'` (empty-quote pairs left the braces unquoted) across the `add_connection_*` scripts — the same bug fixed in `whirl` earlier.
- `SC2155`: split `local X=$(...)` / `export SPARK_HOME=$(...)` declare+assign.
- `SC2046`: quote the `--key` value containing `$(date …)` in `add_mockdata`.
- `SC2128`: `${BASH_SOURCE}` → `${BASH_SOURCE[0]}`.
- `SC2044`: justified `# shellcheck disable` in the sftp mock-data script (controlled, space-free filenames).

**B2 — CI**: the `shellcheck` job now also lints every setup script at `--severity=warning` (info-level `SC2086` quoting noise is intentionally deferred to a follow-up). The main `whirl` script is still linted with `-x`.

**B3 — `tests/test_setup_scripts.py`**: airflow-free pytest conventions asserting each setup script has the bash shebang and `NN_name.sh` naming, and that every `whirl.setup.d` script enables `set -e` near the top (locks in the Topic 3 invariant). `compose.*` scripts are sourced under `whirl`'s own `set -e`, so the errexit check is scoped to `whirl.setup.d`.

## Validation
`shellcheck --severity=warning` over all **68** setup scripts is clean; all modified scripts pass `bash -n`; the conventions suite (**191 checks**) passes with a bare pytest (no airflow needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)